### PR TITLE
Enh/cleanup continued

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
         "jsdoc"
     ],
     "rules": {
+      "camelcase": 2,
       "no-console": 0,
       "no-undef": 2,
       "no-compare-neg-zero": 2,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -45,6 +45,7 @@
       "no-return-await": 2,
       "no-self-assign": 2,
       "no-self-compare": 2,
+      "no-shadow": 2,
       "no-unused-vars": ["error", { "ignoreRestSiblings": true }],
       "no-unused-expressions": 0,
       "no-useless-return": 2,

--- a/examples/convolution_jedi_vs_sith.js
+++ b/examples/convolution_jedi_vs_sith.js
@@ -14,13 +14,13 @@ const rectifiers = require('../lib/rectifiers');
  */
 function task() {
     const net = new Net({
-        input_architecture: [9, 9, 3],
-        learning_rate: 0.000001,
-        layer_configs: [
+        inputArchitecture: [9, 9, 3],
+        learningRate: 0.000001,
+        layerConfigs: [
             {
                 type: 'CONVOLUTIONAL',
                 options: {
-                    filter_architecture: [3, 3, 1],
+                    filterArchitecture: [3, 3, 1],
                     depth: 3,
                     stride: 1,
                     rectifier: rectifiers.relu,
@@ -41,12 +41,12 @@ function task() {
         'sith': [0, 1]
     };
     
-    const train_promises = [
+    const trainPromises = [
         net.loadImageDirectory({'directory': './data/training_9/jedi'}),
         net.loadImageDirectory({'directory': './data/training_9/sith'})
     ];
     
-    const test_promises = [
+    const testPromises = [
         net.loadImageDirectory({'directory': './data/testing_9/sith'}),
         net.loadImageDirectory({'directory': './data/testing_9/jedi'}),
         net.loadImageDirectory({'directory': './data/testing_9/sam'}),
@@ -63,45 +63,45 @@ function task() {
      * @param {*} tim 
      */
     function test(sith, jedi, sam, claude, tim) {
-        sith.forEach((test_image) => {
-            const prediction = net.predict(test_image);
+        sith.forEach((testImage) => {
+            const prediction = net.predict(testImage);
             console.log('Test prediction for sith:', prediction);
         });
     
-        jedi.forEach((test_image) => {
-            const prediction = net.predict(test_image);
+        jedi.forEach((testImage) => {
+            const prediction = net.predict(testImage);
             console.log('Test prediction for jedi:', prediction);
         });
     
-        claude.forEach((test_image) => {
-            const prediction = net.predict(test_image);
+        claude.forEach((testImage) => {
+            const prediction = net.predict(testImage);
             console.log('Test prediction for claude:', prediction);
         });
     
-        tim.forEach((test_image) => {
-            const prediction = net.predict(test_image);
+        tim.forEach((testImage) => {
+            const prediction = net.predict(testImage);
             console.log('Test prediction for tim:', prediction);
         });
     
-        sam.forEach((test_image) => {
-            const prediction = net.predict(test_image);
+        sam.forEach((testImage) => {
+            const prediction = net.predict(testImage);
             console.log('Test prediction for sam:', prediction);
         });
     }
     
     let power = 1;
     
-    Promise.all(train_promises)
-    .then(([jedi_images, sith_images]) => {
-        return Promise.all(test_promises)
+    Promise.all(trainPromises)
+    .then(([jediImages, sithImages]) => {
+        return Promise.all(testPromises)
         .then(([sith, jedi, sam, claude, tim]) => {
             for (var i = 0; i < 500000; i++) {
                 if (Math.random() < 0.5) {
-                    const jedi_index = Math.floor(Math.random() * jedi_images.length);
-                    net.learn(jedi_images[jedi_index], targets.jedi);
+                    const jediIndex = Math.floor(Math.random() * jediImages.length);
+                    net.learn(jediImages[jediIndex], targets.jedi);
                 } else {
-                    const sith_index = Math.floor(Math.random() * sith_images.length);
-                    net.learn(sith_images[sith_index], targets.sith);
+                    const sithIndex = Math.floor(Math.random() * sithImages.length);
+                    net.learn(sithImages[sithIndex], targets.sith);
                 }
     
                 if (i % Math.pow(2, power) == 0) {

--- a/examples/fully_connected_xor.js
+++ b/examples/fully_connected_xor.js
@@ -16,9 +16,9 @@ const rectifiers = require('../lib/rectifiers');
  */
 function task() {
     const net = new Net({
-        input_architecture: [2],
-        learning_rate: 0.02,
-        layer_configs: [
+        inputArchitecture: [2],
+        learningRate: 0.02,
+        layerConfigs: [
             {
                 type: 'FULLY_CONNECTED',
                 options: {
@@ -36,7 +36,7 @@ function task() {
         ]
     });
     
-    for (var i = 0; i < 80000; i++) {
+    for (var i = 0; i < 100000; i++) {
         const input = [];
         let target = [0];
     

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -7,8 +7,8 @@ const codes = {
 };
 
 const errors = {
-    INCOMPATIBLE_FILTER: ({ input_length, filter_length, stride, res }) => {
-        const explanation = `(${input_length} - (${filter_length} - ${stride})) / ${stride} = ${res}`;
+    INCOMPATIBLE_FILTER: ({ inputLength, filterLength, stride, res }) => {
+        const explanation = `(${inputLength} - (${filterLength} - ${stride})) / ${stride} = ${res}`;
 
         const err = new Error(`Incompatible combination of input structure, filter structure, and stride: ${explanation}`);
         err.code = codes.INCOMPATIBLE_FILTER;

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -27,6 +27,7 @@ class Layer {
         this.net = net;
         this.inLayer = inLayer;
         this.rectifier = rectifier;
+        this.neuronsByState = {};
         this._states = null;
     }
 
@@ -114,14 +115,13 @@ class FullyConnectedLayer extends Layer {
                 }
             } else {
                 const neuron = new Neuron({ layer: that });
-                if (inLayer) {
-                    that.createConnections({ neuron, inLayer });
+                if (that.inLayer) {
+                    that.createConnections({ neuron, inLayer: that.inLayer });
                 }
                 that.neuronsByState[state] = neuron;
             }
         }
 
-        this.neuronsByState = {};
         assignNeuronsRecursive();
     }
 
@@ -129,14 +129,13 @@ class FullyConnectedLayer extends Layer {
      * Connects neuron to all neurons in previous layer
      * @param options - options object
      * @param options.neuron - new neuron
-     * @param options.inLayer - previous layer
      */
-    createConnections({ neuron, inLayer }) {
+    createConnections({ neuron }) {
         // create connections to all neurons in input layer
         let sum = 0;
 
-        inLayer.states.forEach((inNeuronState) => {
-            const inNeuron = inLayer.neuronsByState[inNeuronState];
+        this.inLayer.states.forEach((inNeuronState) => {
+            const inNeuron = this.inLayer.neuronsByState[inNeuronState];
             const weight = Math.random();
             sum += weight;
 
@@ -179,13 +178,10 @@ class ConvolutionalLayer extends Layer {
     constructor({ inLayer, net, rectifier, depth, filterArchitecture, stride }) {
         // only fully-connected layers can be input layer
         super({ inLayer, net, rectifier });
-
-        this.neuronsByState = {};
         this.filters = [];
 
         for (let i = 0; i < depth; i++) {
             const filter = this.createFilterFromArchitecture({
-                net: this,
                 architecture: filterArchitecture
             });
 
@@ -193,7 +189,6 @@ class ConvolutionalLayer extends Layer {
         }
 
         this.architecture = this.generateArchitecture({
-            inputStructure: inLayer.architecture,
             filterArchitecture,
             stride,
         });
@@ -227,7 +222,6 @@ class ConvolutionalLayer extends Layer {
                     neuronState: state.split('x')[1],
                     filterArchitecture,
                     filterNumber,
-                    inLayer,
                     stride,
                 }); 
             }
@@ -242,18 +236,18 @@ class ConvolutionalLayer extends Layer {
     /**
      * Calculates architecture based on parameters
      * @param {Object} options 
-     * @param {Array<Number>} inputStructure
      * @param {Array<Number>} filterArchitecture
      * @param {Number} stride
      */
-    generateArchitecture({ inputStructure, filterArchitecture, stride }) {
+    generateArchitecture({ filterArchitecture, stride }) {
         const architecture = [];
-        for (let j = 0; j < inputStructure.length; j++) {
-            const numNeurons = (inputStructure[j] - (filterArchitecture[j] - stride)) / stride;
+        for (let j = 0; j < this.inLayer.architecture.length; j++) {
+            const dimension = this.inLayer.architecture[j];
+            const numNeurons = (dimension - (filterArchitecture[j] - stride)) / stride;
 
             if (!numNeurons || !Number.isInteger(numNeurons) || numNeurons < 1) {
                 throw errors.errors.INCOMPATIBLE_FILTER({
-                    inputLength: inputStructure[j],
+                    inputLength: dimension,
                     filterLength: filterArchitecture[j],
                     res: numNeurons,
                     stride,
@@ -269,20 +263,19 @@ class ConvolutionalLayer extends Layer {
      * @param {Object} options 
      * @param {String} options.state
      * @param {Array<Number>} options.inNeuronCoords
-     * @param {Layer} options.inLayer
      * @param {Neuron} options.neuron
      * @param {Number} options.inFilterNumber
      * @param {Number} options.filterNumber
 
      */
-    createConnection({ state, inNeuronCoords, inLayer, neuron, inFilterNumber, filterNumber }) {
+    createConnection({ state, inNeuronCoords, neuron, inFilterNumber, filterNumber }) {
         let inNeuronKey = inNeuronCoords.join('.');
 
         if (typeof inFilterNumber === 'number') {
             inNeuronKey = [inFilterNumber, 'x', inNeuronKey].join('');
         }
 
-        const inNeuron = inLayer.neuronsByState[inNeuronKey];
+        const inNeuron = this.inLayer.neuronsByState[inNeuronKey];
 
         const connection = new Connection({
             inNeuron,
@@ -303,10 +296,9 @@ class ConvolutionalLayer extends Layer {
      * @param {Number} options.filterNumber
      * @param {String} options.neuronState
      * @param {Number} options.stride
-     * @param {Layer} options.inLayer
      */
-    createConnections({ neuron, filterArchitecture, filterNumber, neuronState, stride, inLayer }) {
-        const numInFilters = inLayer.filters ? inLayer.filters.length : 0;
+    createConnections({ neuron, filterArchitecture, filterNumber, neuronState, stride }) {
+        const numInFilters = this.inLayer.filters ? this.inLayer.filters.length : 0;
         const that = this;
 
         /**
@@ -333,10 +325,10 @@ class ConvolutionalLayer extends Layer {
 
                 if (numInFilters > 0) {
                     for (let k = 0; k < numInFilters; k++) {
-                        that.createConnection({ state, inNeuronCoords, inLayer, neuron, filterNumber, inFilterNumber: k });
+                        that.createConnection({ state, inNeuronCoords, neuron, filterNumber, inFilterNumber: k });
                     }
                 } else {
-                    that.createConnection({ state, inNeuronCoords, inLayer, neuron, filterNumber, inFilterNumber: null });
+                    that.createConnection({ state, inNeuronCoords, neuron, filterNumber, inFilterNumber: null });
                 }
             }
         }
@@ -405,12 +397,10 @@ class PoolingLayer extends Layer {
         }
 
         this.architecture = this.createPoolingArchitecture({ 
-            inputArchitecture: inLayer.architecture,
             spatialExtent
         });
 
         this.createConnections({
-            inLayer,
             spatialExtent,
         });
     }
@@ -418,13 +408,11 @@ class PoolingLayer extends Layer {
     /**
      * Creates connections
      * @param {Object} options 
-     * @param {Layer} options.inLayer
      * @param {Number} options.spatialExtent 
      */
-    createConnections({ inLayer, spatialExtent }) {
+    createConnections({ spatialExtent }) {
         const that = this;
-        this.neuronsByState = {};
-        const inputFilters = inLayer.filters.length;
+        const inputFilters = this.inLayer.filters.length;
 
         /**
          * 
@@ -476,7 +464,7 @@ class PoolingLayer extends Layer {
                     const inputStates = getInputStates({ inputFilters, state, filterNumber });
 
                     inputStates.forEach((inputState) => {
-                        const inNeuron = inLayer.neuronsByState[inputState];
+                        const inNeuron = that.inLayer.neuronsByState[inputState];
 
                         // connection must have weight 1 for error to propagate
                         const connection = new Connection({
@@ -502,22 +490,22 @@ class PoolingLayer extends Layer {
     /**
      * 
      * @param {Object} options
-     * @param {Array<Number>} options.inputArchitecture
      * @param {Number} options.spatialExtent
      */
-    createPoolingArchitecture({ inputArchitecture, spatialExtent }) {
+    createPoolingArchitecture({ spatialExtent }) {
         const architecture = [];
 
-        for (let i = 0; i < inputArchitecture.length; i++) {
+        for (let i = 0; i < this.inLayer.architecture.length; i++) {
+            const inputDimension = this.inLayer.architecture[i];
             if (i <= 1) {
-                const dimension = inputArchitecture[i] / spatialExtent;
+                const dimension = inputDimension / spatialExtent;
                 if (!Number.isInteger(dimension)) {
-                    const reason = `${inputArchitecture[i]} % ${spatialExtent} = ${dimension}`;
+                    const reason = `${inputDimension} % ${spatialExtent} = ${dimension}`;
                     throw new Error(`Pooling extent not compatible with input architecture! ${reason}`);
                 }
                 architecture.push(dimension);
             } else {
-                architecture.push(inputArchitecture[i]);
+                architecture.push(inputDimension);
             }
         }
         return architecture;

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -27,6 +27,17 @@ class Layer {
         this.net = net;
         this.in_layer = in_layer;
         this.rectifier = rectifier;
+        this._states = null;
+    }
+
+    /**
+     * Get all neuron states pre-fetched to save time on iteration
+     */
+    get states() {
+        if (!this._states) {
+            this._states = Object.keys(this.neurons);
+        }
+        return this._states;
     }
 
     /**
@@ -34,8 +45,8 @@ class Layer {
      * @return {Array<Number>}
      */
     activate() {
-        Object.values(this.neurons).forEach((neuron) => {
-            neuron.activate();
+        this.states.forEach((state) => {
+            this.neurons[state].activate();
         });
 
         return this.activations;
@@ -46,12 +57,12 @@ class Layer {
      * @param {Array<Number>} target_vector 
      */
     propagate(target_vector) {
-        const neurons = Object.values(this.neurons);
-        for (let i = 0; i < neurons.length; i++) {
+        for (let i = 0; i < this.states.length; i++) {
+            const state = this.states[i];
             if (target_vector) {
-                neurons[i].propagate(target_vector[i]);
+                this.neurons[state].propagate(target_vector[i]);
             } else {
-                neurons[i].propagate();
+                this.neurons[state].propagate();
             }
         }
     }
@@ -60,12 +71,13 @@ class Layer {
      * @return {Array<Number>}
      */
     get activations() {
-        return Object.values(this.neurons).map(neuron => neuron.activation);
+        return this.states.map(state => this.neurons[state].activation);
     }
 }
 
 /**
- * Fully connected layers are expressed with one dimension of neurons
+ * Fully connected layers have neurons which are connected to every neuron in the previous layer.
+ * They are the only layer type which may be used as the input layer.
  *
  * @class
  */
@@ -123,7 +135,8 @@ class FullyConnectedLayer extends Layer {
         // create connections to all neurons in input layer
         let sum = 0;
 
-        Object.values(in_layer.neurons).forEach((in_neuron) => {
+        in_layer.states.forEach((in_neuron_state) => {
+            const in_neuron = in_layer.neurons[in_neuron_state];
             const weight = Math.random();
             sum += weight;
 

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -35,7 +35,7 @@ class Layer {
      */
     get states() {
         if (!this._states) {
-            this._states = Object.keys(this.neurons);
+            this._states = Object.keys(this.neuronsByState);
         }
         return this._states;
     }
@@ -46,7 +46,7 @@ class Layer {
      */
     activate() {
         this.states.forEach((state) => {
-            this.neurons[state].activate();
+            this.neuronsByState[state].activate();
         });
 
         return this.activations;
@@ -60,9 +60,9 @@ class Layer {
         for (let i = 0; i < this.states.length; i++) {
             const state = this.states[i];
             if (target_vector) {
-                this.neurons[state].propagate(target_vector[i]);
+                this.neuronsByState[state].propagate(target_vector[i]);
             } else {
-                this.neurons[state].propagate();
+                this.neuronsByState[state].propagate();
             }
         }
     }
@@ -71,7 +71,7 @@ class Layer {
      * @return {Array<Number>}
      */
     get activations() {
-        return this.states.map(state => this.neurons[state].activation);
+        return this.states.map(state => this.neuronsByState[state].activation);
     }
 }
 
@@ -117,11 +117,11 @@ class FullyConnectedLayer extends Layer {
                 if (in_layer) {
                     that.createConnections({ neuron, in_layer });
                 }
-                that.neurons[state] = neuron;
+                that.neuronsByState[state] = neuron;
             }
         }
 
-        this.neurons = {};
+        this.neuronsByState = {};
         assignNeuronsRecursive();
     }
 
@@ -136,7 +136,7 @@ class FullyConnectedLayer extends Layer {
         let sum = 0;
 
         in_layer.states.forEach((in_neuron_state) => {
-            const in_neuron = in_layer.neurons[in_neuron_state];
+            const in_neuron = in_layer.neuronsByState[in_neuron_state];
             const weight = Math.random();
             sum += weight;
 
@@ -180,7 +180,7 @@ class ConvolutionalLayer extends Layer {
         // only fully-connected layers can be input layer
         super({ in_layer, net, rectifier });
 
-        this.neurons = {};
+        this.neuronsByState = {};
         this.filters = [];
 
         for (let i = 0; i < depth; i++) {
@@ -219,11 +219,11 @@ class ConvolutionalLayer extends Layer {
                     assignNeuronsRecursive(index + 1, nested_state, filter_no);
                 }
             } else {
-                that.neurons[state] = new Neuron({
+                that.neuronsByState[state] = new Neuron({
                     layer: that
                 });
                 that.createConnections({
-                    neuron: that.neurons[state],
+                    neuron: that.neuronsByState[state],
                     neuron_state: state.split('x')[1],
                     filter_architecture,
                     filter_no,
@@ -282,7 +282,7 @@ class ConvolutionalLayer extends Layer {
             in_neuron_key = [in_filter_no, 'x', in_neuron_key].join('');
         }
 
-        const in_neuron = in_layer.neurons[in_neuron_key];
+        const in_neuron = in_layer.neuronsByState[in_neuron_key];
 
         const connection = new Connection({
             in_neuron,
@@ -423,7 +423,7 @@ class PoolingLayer extends Layer {
      */
     createConnections({ in_layer, spatial_extent }) {
         const that = this;
-        this.neurons = {};
+        this.neuronsByState = {};
         const input_filters = in_layer.filters.length;
 
         /**
@@ -476,7 +476,7 @@ class PoolingLayer extends Layer {
                     const input_states = getInputStates({ input_filters, state, filter_no });
 
                     input_states.forEach((input_state) => {
-                        const in_neuron = in_layer.neurons[input_state];
+                        const in_neuron = in_layer.neuronsByState[input_state];
 
                         // connection must have weight 1 for error to propagate
                         const connection = new Connection({
@@ -491,7 +491,7 @@ class PoolingLayer extends Layer {
                     });
 
                     const neuron_state = `${filter_no}x${state}`;
-                    that.neurons[neuron_state] = neuron;
+                    that.neuronsByState[neuron_state] = neuron;
                 }
             }
         }

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -34,9 +34,9 @@ class Layer {
      * @return {Array<Number>}
      */
     activate() {
-        for (const [, neuron] of this.neuronGenerator()) {
+        Object.values(this.neurons).forEach((neuron) => {
             neuron.activate();
-        }
+        });
 
         return this.activations;
     }
@@ -46,11 +46,12 @@ class Layer {
      * @param {Array<Number>} target_vector 
      */
     propagate(target_vector) {
-        for (const [i, neuron] of this.neuronGenerator()) {
+        const neurons = Object.values(this.neurons);
+        for (let i = 0; i < neurons.length; i++) {
             if (target_vector) {
-                neuron.propagate(target_vector[i]);
+                neurons[i].propagate(target_vector[i]);
             } else {
-                neuron.propagate();
+                neurons[i].propagate();
             }
         }
     }
@@ -60,17 +61,6 @@ class Layer {
      */
     get activations() {
         return Object.values(this.neurons).map(neuron => neuron.activation);
-    }
-
-    /**
-     * @return {Array<Neuron>}
-     */
-    *neuronGenerator() {
-        const neurons = Object.values(this.neurons);
-        for (let i = 0; i < neurons.length; i++) {
-            yield [i, neurons[i]];
-        }
-        return neurons.length;
     }
 }
 

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -20,19 +20,13 @@ class Layer {
      * @param {Object} options
      * @param {Net} net
      * @param {Layer} in_layer
-     * @param {Boolean} is_input
+     * @param {Function} rectifier
      *  
      */
-    constructor({ net, in_layer, rectifier }) {
+    constructor({ net, in_layer, rectifier = null }) {
         this.net = net;
         this.in_layer = in_layer;
-
-        // rectifier is only used for non-input layers
-        if (rectifier) {
-            this.rectifier = rectifier;
-        } else {
-            this.rectifier = null;
-        }
+        this.rectifier = rectifier;
     }
 
     /**
@@ -89,23 +83,14 @@ class FullyConnectedLayer extends Layer {
     /**
      * @param {Object} options
      * @param {Array<Number>} options.architecture - number of neurons in layers
-     * @param {Layer} options.in_layer - layer forming incoming connections
+     * @param {Layer|null} options.in_layer - layer forming incoming connections
      * @param {Function} options.rectifier - activation function
      * @param {Net} options.net - the net to which the layer belongs
-     * @param {Boolean} options.is_input - true if the layer represents the net's input
      */
-    constructor({ architecture, in_layer, rectifier, net, is_input }) {
-        super({ in_layer, is_input, net, rectifier });
+    constructor({ architecture, in_layer, rectifier, net }) {
+        super({ in_layer, net, rectifier });
 
         this.architecture = architecture;
-
-        const neuron_args = {
-            layer: this
-        };
-
-        if (!is_input) {
-            neuron_args.in_neurons = in_layer.neurons;
-        }
 
         if (!architecture || !(architecture instanceof Array) || !architecture.length) {
             throw new Error('Architecture must be array with at least one dimension');
@@ -121,17 +106,53 @@ class FullyConnectedLayer extends Layer {
         function assignNeuronsRecursive(index, state) {
             index = index || 0;
             if (index < architecture.length) {
-                for (var i = 0; i < architecture[index]; i++) {
+                for (let i = 0; i < architecture[index]; i++) {
                     const nested_state = state ? [state, i].join('.'): String(i);
                     assignNeuronsRecursive(index + 1, nested_state);
                 }
             } else {
-                that.neurons[state] = new Neuron(neuron_args);
+                const neuron = new Neuron({ layer: that });
+                if (in_layer) {
+                    that.createConnections({ neuron, in_layer });
+                }
+                that.neurons[state] = neuron;
             }
         }
 
         this.neurons = {};
         assignNeuronsRecursive();
+    }
+
+    /**
+     * Connects neuron to all neurons in previous layer
+     * @param options - options object
+     * @param options.neuron - new neuron
+     * @param options.in_layer - previous layer
+     */
+    createConnections({ neuron, in_layer }) {
+        // create connections to all neurons in input layer
+        let sum = 0;
+
+        Object.values(in_layer.neurons).forEach((in_neuron) => {
+            const weight = Math.random();
+            sum += weight;
+
+            const connection = new Connection({
+                in_neuron: in_neuron,
+                out_neuron: neuron,
+                weight
+            });
+
+            // update on both ends of the connection
+            neuron.connections.in[in_neuron._id] = connection;
+            in_neuron.connections.out[neuron._id] = connection;
+        });
+
+        // ensure that all weights add to 1
+        const multiplier = 1 / sum;
+        Object.values(neuron.connections.in).forEach((connection) => {
+            connection.params.weight *= multiplier;
+        });
     }
 }
 
@@ -146,28 +167,20 @@ class ConvolutionalLayer extends Layer {
      * @param {Object} options
      * @param {Array<Number>} options.architecture - number of neurons in layers
      * @param {Layer} options.in_layer - layer forming incoming connections
-     * @param {Boolean} options.is_input - true if the layer represents the net's input
      * @param {Net} options.net - the net to which the layer belongs
      * @param {Function} options.rectifier - activation function
      * @param {Number} options.depth - depth
      * @param {Array<Number>} options.filter_architecture - architecture of filters
      * @param {Number} options.stride - distance between filters
      */
-    constructor({ in_layer, is_input, net, rectifier, depth, filter_architecture, stride }) {
-        super({ in_layer, is_input, net, rectifier });
+    constructor({ in_layer, net, rectifier, depth, filter_architecture, stride }) {
+        // only fully-connected layers can be input layer
+        super({ in_layer, net, rectifier });
 
         this.neurons = {};
         this.filters = [];
 
-        const neuron_args = {
-            layer: this
-        };
-
-        if (!is_input) {
-            neuron_args.in_neurons = in_layer.neurons;
-        }
-
-        for (var i = 0; i < depth; i++) {
+        for (let i = 0; i < depth; i++) {
             const filter = this.createFilterFromArchitecture({
                 net: this,
                 architecture: filter_architecture
@@ -193,7 +206,7 @@ class ConvolutionalLayer extends Layer {
         function assignNeuronsRecursive(index, state, filter_no) {
             index = index || 0;
             if (index < that.architecture.length) {
-                for (var i = 0; i < that.architecture[index]; i++) {
+                for (let i = 0; i < that.architecture[index]; i++) {
                     let nested_state;
                     if (typeof state === 'string' && state.includes('x')) {
                         nested_state = [state, i].join('.');
@@ -203,9 +216,9 @@ class ConvolutionalLayer extends Layer {
                     assignNeuronsRecursive(index + 1, nested_state, filter_no);
                 }
             } else {
-                neuron_args.in_neurons = {};
-
-                that.neurons[state] = new Neuron(neuron_args);
+                that.neurons[state] = new Neuron({
+                    layer: that
+                });
                 that.createConnections({
                     neuron: that.neurons[state],
                     neuron_state: state.split('x')[1],
@@ -217,7 +230,7 @@ class ConvolutionalLayer extends Layer {
             }
         }
 
-        for (var filter_no = 0; filter_no < depth; filter_no++) {
+        for (let filter_no = 0; filter_no < depth; filter_no++) {
             // prefix all neuron states with filter number (ex: "3x0.3.1")
             assignNeuronsRecursive(null, null, filter_no);
         }
@@ -232,7 +245,7 @@ class ConvolutionalLayer extends Layer {
      */
     generateArchitecture({ input_structure, filter_architecture, stride }) {
         const architecture = [];
-        for (var j = 0; j < input_structure.length; j++) {
+        for (let j = 0; j < input_structure.length; j++) {
             const num_neurons = (input_structure[j] - (filter_architecture[j] - stride)) / stride;
 
             if (!num_neurons || !Number.isInteger(num_neurons) || num_neurons < 1) {
@@ -301,7 +314,7 @@ class ConvolutionalLayer extends Layer {
         function nest(index, state) {
             index = index || 0;
             if (index < filter_architecture.length) {
-                for (var i = 0; i < filter_architecture[index]; i++) {
+                for (let i = 0; i < filter_architecture[index]; i++) {
                     const nested_state = state ? [state, i].join('.'): String(i);
                     nest(index + 1, nested_state);
                 }
@@ -310,13 +323,13 @@ class ConvolutionalLayer extends Layer {
                 const connection_coords = state.split('.');
 
                 const in_neuron_coords = [];
-                for (var j = 0; j < neuron_coords.length; j++) {
+                for (let j = 0; j < neuron_coords.length; j++) {
                     const coord = parseInt(neuron_coords[j], 10) * stride + parseInt(connection_coords[j], 10);
                     in_neuron_coords.push(coord);
                 }
 
                 if (num_in_filters > 0) {
-                    for (var k = 0; k < num_in_filters; k++) {
+                    for (let k = 0; k < num_in_filters; k++) {
                         that.createConnection({ state, in_neuron_coords, in_layer, neuron, filter_no, in_filter_no: k });
                     }
                 } else {
@@ -345,7 +358,7 @@ class ConvolutionalLayer extends Layer {
         function nest(index, state) {
             index = index || 0;
             if (index < architecture.length) {
-                for (var i = 0; i < architecture[index]; i++) {
+                for (let i = 0; i < architecture[index]; i++) {
                     const nested_state = state ? [state, i].join('.'): String(i);
                     nest(index + 1, nested_state);
                 }
@@ -381,11 +394,8 @@ class PoolingLayer extends Layer {
      * @param {Net} options.net
      */
     constructor({ spatial_extent, in_layer, net }) {
-        const is_input = false;
         const rectifier = null;
-        super({ in_layer, is_input, net, rectifier });
-
-        const neuron_args = { 'layer': this, 'pooling': true };
+        super({ in_layer, net, rectifier });
 
         if (!spatial_extent || !(Number.isInteger(spatial_extent)) || spatial_extent < 2) {
             throw new Error('spatial_extent must be an integer greater than 1');
@@ -397,8 +407,6 @@ class PoolingLayer extends Layer {
         });
 
         this.createConnections({
-            layer: this,
-            neuron_args,
             in_layer,
             spatial_extent,
         });
@@ -408,12 +416,11 @@ class PoolingLayer extends Layer {
      * Creates connections
      * @param {Object} options 
      * @param {Layer} options.in_layer
-     * @param {Layer} options.layer 
-     * @param {Object} options.neuron_args 
      * @param {Number} options.spatial_extent 
      */
-    createConnections({ in_layer, layer, neuron_args, spatial_extent }) {
-        layer.neurons = {};
+    createConnections({ in_layer, spatial_extent }) {
+        const that = this;
+        this.neurons = {};
         const input_filters = in_layer.filters.length;
 
         /**
@@ -421,9 +428,8 @@ class PoolingLayer extends Layer {
          * @param {Object} options 
          * @param {String} options.state
          * @param {Number} options.filter_no
-         * @param {Number} options.spatial_extent
          */
-        function getInputStates({ state, filter_no, spatial_extent }) {
+        function getInputStates({ state, filter_no }) {
             const base_state = state.split('.');
             base_state[0] *= spatial_extent;
             base_state[1] *= spatial_extent;
@@ -431,11 +437,11 @@ class PoolingLayer extends Layer {
             const neuron_ids = [];
             let new_state;
 
-            for (var i = 0; i < spatial_extent; i++) {
+            for (let i = 0; i < spatial_extent; i++) {
                 // copy base_state
                 new_state = base_state.slice();
                 new_state[0] += i;
-                for (var j = 0; j < spatial_extent; j++) {
+                for (let j = 0; j < spatial_extent; j++) {
                     new_state[1] += j;
                     const neuron_id = `${filter_no}x${new_state.join('.')}`;
                     neuron_ids.push(neuron_id);
@@ -452,19 +458,19 @@ class PoolingLayer extends Layer {
          */
         function nest(index, state) {
             index = index || 0;
-            if (index < layer.architecture.length) {
-                for (var i = 0; i < layer.architecture[index]; i++) {
+            if (index < that.architecture.length) {
+                for (let i = 0; i < that.architecture[index]; i++) {
                     const nested_state = state ? [state, i].join('.'): String(i);
                     nest(index + 1, nested_state);
                 }
             } else {
-                for (var filter_no = 0; filter_no < input_filters; filter_no++) {
-                    const neuron_state = `${filter_no}x${state}`;
+                for (let filter_no = 0; filter_no < input_filters; filter_no++) {
+                    const neuron = new Neuron({
+                        layer: that,
+                        pooling: true
+                    });
 
-                    layer.neurons[neuron_state] = new Neuron(neuron_args);
-                    const neuron = layer.neurons[neuron_state];
-
-                    const input_states = getInputStates({ input_filters, state, filter_no, spatial_extent });
+                    const input_states = getInputStates({ input_filters, state, filter_no });
 
                     input_states.forEach((input_state) => {
                         const in_neuron = in_layer.neurons[input_state];
@@ -477,9 +483,12 @@ class PoolingLayer extends Layer {
                         });
 
                         // update on both ends of the connection
-                        neuron.connections.in[neuron._id] = connection;
-                        in_neuron.connections.out[in_neuron._id] = connection;
+                        neuron.connections.in[in_neuron._id] = connection;
+                        in_neuron.connections.out[neuron._id] = connection;
                     });
+
+                    const neuron_state = `${filter_no}x${state}`;
+                    that.neurons[neuron_state] = neuron;
                 }
             }
         }
@@ -496,14 +505,14 @@ class PoolingLayer extends Layer {
     createPoolingArchitecture({ input_architecture, spatial_extent }) {
         const architecture = [];
 
-        for (var i = 0; i < input_architecture.length; i++) {
+        for (let i = 0; i < input_architecture.length; i++) {
             if (i <= 1) {
-                const dim = input_architecture[i] / spatial_extent;
-                if (!Number.isInteger(dim)) {
-                    const reason = `${input_architecture[i]} % ${spatial_extent} = ${dim}`;
+                const dimension = input_architecture[i] / spatial_extent;
+                if (!Number.isInteger(dimension)) {
+                    const reason = `${input_architecture[i]} % ${spatial_extent} = ${dimension}`;
                     throw new Error(`Pooling extent not compatible with input architecture! ${reason}`);
                 }
-                architecture.push(dim);
+                architecture.push(dimension);
             } else {
                 architecture.push(input_architecture[i]);
             }

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -19,13 +19,13 @@ class Layer {
      * 
      * @param {Object} options
      * @param {Net} net
-     * @param {Layer} in_layer
+     * @param {Layer} inLayer
      * @param {Function} rectifier
      *  
      */
-    constructor({ net, in_layer, rectifier = null }) {
+    constructor({ net, inLayer, rectifier = null }) {
         this.net = net;
-        this.in_layer = in_layer;
+        this.inLayer = inLayer;
         this.rectifier = rectifier;
         this._states = null;
     }
@@ -54,13 +54,13 @@ class Layer {
 
     /**
      * Adjusts weights based on error
-     * @param {Array<Number>} target_vector 
+     * @param {Array<Number>} targetVector 
      */
-    propagate(target_vector) {
+    propagate(targetVector) {
         for (let i = 0; i < this.states.length; i++) {
             const state = this.states[i];
-            if (target_vector) {
-                this.neuronsByState[state].propagate(target_vector[i]);
+            if (targetVector) {
+                this.neuronsByState[state].propagate(targetVector[i]);
             } else {
                 this.neuronsByState[state].propagate();
             }
@@ -85,12 +85,12 @@ class FullyConnectedLayer extends Layer {
     /**
      * @param {Object} options
      * @param {Array<Number>} options.architecture - number of neurons in layers
-     * @param {Layer|null} options.in_layer - layer forming incoming connections
+     * @param {Layer|null} options.inLayer - layer forming incoming connections
      * @param {Function} options.rectifier - activation function
      * @param {Net} options.net - the net to which the layer belongs
      */
-    constructor({ architecture, in_layer, rectifier, net }) {
-        super({ in_layer, net, rectifier });
+    constructor({ architecture, inLayer, rectifier, net }) {
+        super({ inLayer, net, rectifier });
 
         this.architecture = architecture;
 
@@ -109,13 +109,13 @@ class FullyConnectedLayer extends Layer {
             index = index || 0;
             if (index < architecture.length) {
                 for (let i = 0; i < architecture[index]; i++) {
-                    const nested_state = state ? [state, i].join('.'): String(i);
-                    assignNeuronsRecursive(index + 1, nested_state);
+                    const nestedState = state ? [state, i].join('.'): String(i);
+                    assignNeuronsRecursive(index + 1, nestedState);
                 }
             } else {
                 const neuron = new Neuron({ layer: that });
-                if (in_layer) {
-                    that.createConnections({ neuron, in_layer });
+                if (inLayer) {
+                    that.createConnections({ neuron, inLayer });
                 }
                 that.neuronsByState[state] = neuron;
             }
@@ -129,26 +129,26 @@ class FullyConnectedLayer extends Layer {
      * Connects neuron to all neurons in previous layer
      * @param options - options object
      * @param options.neuron - new neuron
-     * @param options.in_layer - previous layer
+     * @param options.inLayer - previous layer
      */
-    createConnections({ neuron, in_layer }) {
+    createConnections({ neuron, inLayer }) {
         // create connections to all neurons in input layer
         let sum = 0;
 
-        in_layer.states.forEach((in_neuron_state) => {
-            const in_neuron = in_layer.neuronsByState[in_neuron_state];
+        inLayer.states.forEach((inNeuronState) => {
+            const inNeuron = inLayer.neuronsByState[inNeuronState];
             const weight = Math.random();
             sum += weight;
 
             const connection = new Connection({
-                in_neuron: in_neuron,
-                out_neuron: neuron,
+                inNeuron,
+                outNeuron: neuron,
                 weight
             });
 
             // update on both ends of the connection
-            neuron.connections.in[in_neuron._id] = connection;
-            in_neuron.connections.out[neuron._id] = connection;
+            neuron.connections.in[inNeuron._id] = connection;
+            inNeuron.connections.out[neuron._id] = connection;
         });
 
         // ensure that all weights add to 1
@@ -169,16 +169,16 @@ class ConvolutionalLayer extends Layer {
     /**
      * @param {Object} options
      * @param {Array<Number>} options.architecture - number of neurons in layers
-     * @param {Layer} options.in_layer - layer forming incoming connections
+     * @param {Layer} options.inLayer - layer forming incoming connections
      * @param {Net} options.net - the net to which the layer belongs
      * @param {Function} options.rectifier - activation function
      * @param {Number} options.depth - depth
-     * @param {Array<Number>} options.filter_architecture - architecture of filters
+     * @param {Array<Number>} options.filterArchitecture - architecture of filters
      * @param {Number} options.stride - distance between filters
      */
-    constructor({ in_layer, net, rectifier, depth, filter_architecture, stride }) {
+    constructor({ inLayer, net, rectifier, depth, filterArchitecture, stride }) {
         // only fully-connected layers can be input layer
-        super({ in_layer, net, rectifier });
+        super({ inLayer, net, rectifier });
 
         this.neuronsByState = {};
         this.filters = [];
@@ -186,15 +186,15 @@ class ConvolutionalLayer extends Layer {
         for (let i = 0; i < depth; i++) {
             const filter = this.createFilterFromArchitecture({
                 net: this,
-                architecture: filter_architecture
+                architecture: filterArchitecture
             });
 
             this.filters.push(filter);
         }
 
         this.architecture = this.generateArchitecture({
-            input_structure: in_layer.architecture,
-            filter_architecture,
+            inputStructure: inLayer.architecture,
+            filterArchitecture,
             stride,
         });
 
@@ -204,19 +204,19 @@ class ConvolutionalLayer extends Layer {
          * Recursive function for assigning neurons
          * @param {Number} index 
          * @param {String} state 
-         * @param {Number} filter_no 
+         * @param {Number} filterNumber 
          */
-        function assignNeuronsRecursive(index, state, filter_no) {
+        function assignNeuronsRecursive(index, state, filterNumber) {
             index = index || 0;
             if (index < that.architecture.length) {
                 for (let i = 0; i < that.architecture[index]; i++) {
-                    let nested_state;
+                    let nestedState;
                     if (typeof state === 'string' && state.includes('x')) {
-                        nested_state = [state, i].join('.');
+                        nestedState = [state, i].join('.');
                     } else {
-                        nested_state = [filter_no, i].join('x');
+                        nestedState = [filterNumber, i].join('x');
                     }
-                    assignNeuronsRecursive(index + 1, nested_state, filter_no);
+                    assignNeuronsRecursive(index + 1, nestedState, filterNumber);
                 }
             } else {
                 that.neuronsByState[state] = new Neuron({
@@ -224,42 +224,42 @@ class ConvolutionalLayer extends Layer {
                 });
                 that.createConnections({
                     neuron: that.neuronsByState[state],
-                    neuron_state: state.split('x')[1],
-                    filter_architecture,
-                    filter_no,
-                    in_layer,
+                    neuronState: state.split('x')[1],
+                    filterArchitecture,
+                    filterNumber,
+                    inLayer,
                     stride,
                 }); 
             }
         }
 
-        for (let filter_no = 0; filter_no < depth; filter_no++) {
+        for (let filterNumber = 0; filterNumber < depth; filterNumber++) {
             // prefix all neuron states with filter number (ex: "3x0.3.1")
-            assignNeuronsRecursive(null, null, filter_no);
+            assignNeuronsRecursive(null, null, filterNumber);
         }
     }
 
     /**
      * Calculates architecture based on parameters
      * @param {Object} options 
-     * @param {Array<Number>} input_structure
-     * @param {Array<Number>} filter_architecture
+     * @param {Array<Number>} inputStructure
+     * @param {Array<Number>} filterArchitecture
      * @param {Number} stride
      */
-    generateArchitecture({ input_structure, filter_architecture, stride }) {
+    generateArchitecture({ inputStructure, filterArchitecture, stride }) {
         const architecture = [];
-        for (let j = 0; j < input_structure.length; j++) {
-            const num_neurons = (input_structure[j] - (filter_architecture[j] - stride)) / stride;
+        for (let j = 0; j < inputStructure.length; j++) {
+            const numNeurons = (inputStructure[j] - (filterArchitecture[j] - stride)) / stride;
 
-            if (!num_neurons || !Number.isInteger(num_neurons) || num_neurons < 1) {
+            if (!numNeurons || !Number.isInteger(numNeurons) || numNeurons < 1) {
                 throw errors.errors.INCOMPATIBLE_FILTER({
-                    input_length: input_structure[j],
-                    filter_length: filter_architecture[j],
-                    res: num_neurons,
+                    inputLength: inputStructure[j],
+                    filterLength: filterArchitecture[j],
+                    res: numNeurons,
                     stride,
                 });
             }
-            architecture.push(num_neurons);
+            architecture.push(numNeurons);
         }
         return architecture;
     }
@@ -268,45 +268,45 @@ class ConvolutionalLayer extends Layer {
      * Creates connection between two neurons
      * @param {Object} options 
      * @param {String} options.state
-     * @param {Array<Number>} options.in_neuron_coords
-     * @param {Layer} options.in_layer
+     * @param {Array<Number>} options.inNeuronCoords
+     * @param {Layer} options.inLayer
      * @param {Neuron} options.neuron
-     * @param {Number} options.in_filter_no
-     * @param {Number} options.filter_no
+     * @param {Number} options.inFilterNumber
+     * @param {Number} options.filterNumber
 
      */
-    createConnection({ state, in_neuron_coords, in_layer, neuron, in_filter_no, filter_no }) {
-        let in_neuron_key = in_neuron_coords.join('.');
+    createConnection({ state, inNeuronCoords, inLayer, neuron, inFilterNumber, filterNumber }) {
+        let inNeuronKey = inNeuronCoords.join('.');
 
-        if (typeof in_filter_no === 'number') {
-            in_neuron_key = [in_filter_no, 'x', in_neuron_key].join('');
+        if (typeof inFilterNumber === 'number') {
+            inNeuronKey = [inFilterNumber, 'x', inNeuronKey].join('');
         }
 
-        const in_neuron = in_layer.neuronsByState[in_neuron_key];
+        const inNeuron = inLayer.neuronsByState[inNeuronKey];
 
         const connection = new Connection({
-            in_neuron,
-            out_neuron: neuron,
-            shared_params: neuron.layer.filters[filter_no][state]
+            inNeuron,
+            outNeuron: neuron,
+            sharedParams: neuron.layer.filters[filterNumber][state]
         });
 
         // update on both ends of the connection
-        neuron.connections.in[in_neuron._id] = connection;
-        in_neuron.connections.out[neuron._id] = connection;
+        neuron.connections.in[inNeuron._id] = connection;
+        inNeuron.connections.out[neuron._id] = connection;
     }
 
     /**
      * Creates connections to other layer
      * @param {Object} options
      * @param {Neuron} options.neuron
-     * @param {Array<Number>} options.filter_architecture
-     * @param {Number} options.filter_no
-     * @param {String} options.neuron_state
+     * @param {Array<Number>} options.filterArchitecture
+     * @param {Number} options.filterNumber
+     * @param {String} options.neuronState
      * @param {Number} options.stride
-     * @param {Layer} options.in_layer
+     * @param {Layer} options.inLayer
      */
-    createConnections({ neuron, filter_architecture, filter_no, neuron_state, stride, in_layer }) {
-        const num_in_filters = in_layer.filters ? in_layer.filters.length : 0;
+    createConnections({ neuron, filterArchitecture, filterNumber, neuronState, stride, inLayer }) {
+        const numInFilters = inLayer.filters ? inLayer.filters.length : 0;
         const that = this;
 
         /**
@@ -316,27 +316,27 @@ class ConvolutionalLayer extends Layer {
          */
         function nest(index, state) {
             index = index || 0;
-            if (index < filter_architecture.length) {
-                for (let i = 0; i < filter_architecture[index]; i++) {
-                    const nested_state = state ? [state, i].join('.'): String(i);
-                    nest(index + 1, nested_state);
+            if (index < filterArchitecture.length) {
+                for (let i = 0; i < filterArchitecture[index]; i++) {
+                    const nestedState = state ? [state, i].join('.'): String(i);
+                    nest(index + 1, nestedState);
                 }
             } else {
-                const neuron_coords = neuron_state.split('.');
-                const connection_coords = state.split('.');
+                const neuronCoords = neuronState.split('.');
+                const connectionCoords = state.split('.');
 
-                const in_neuron_coords = [];
-                for (let j = 0; j < neuron_coords.length; j++) {
-                    const coord = parseInt(neuron_coords[j], 10) * stride + parseInt(connection_coords[j], 10);
-                    in_neuron_coords.push(coord);
+                const inNeuronCoords = [];
+                for (let j = 0; j < neuronCoords.length; j++) {
+                    const coord = parseInt(neuronCoords[j], 10) * stride + parseInt(connectionCoords[j], 10);
+                    inNeuronCoords.push(coord);
                 }
 
-                if (num_in_filters > 0) {
-                    for (let k = 0; k < num_in_filters; k++) {
-                        that.createConnection({ state, in_neuron_coords, in_layer, neuron, filter_no, in_filter_no: k });
+                if (numInFilters > 0) {
+                    for (let k = 0; k < numInFilters; k++) {
+                        that.createConnection({ state, inNeuronCoords, inLayer, neuron, filterNumber, inFilterNumber: k });
                     }
                 } else {
-                    that.createConnection({ state, in_neuron_coords, in_layer, neuron, filter_no, in_filter_no: null });
+                    that.createConnection({ state, inNeuronCoords, inLayer, neuron, filterNumber, inFilterNumber: null });
                 }
             }
         }
@@ -362,8 +362,8 @@ class ConvolutionalLayer extends Layer {
             index = index || 0;
             if (index < architecture.length) {
                 for (let i = 0; i < architecture[index]; i++) {
-                    const nested_state = state ? [state, i].join('.'): String(i);
-                    nest(index + 1, nested_state);
+                    const nestedState = state ? [state, i].join('.'): String(i);
+                    nest(index + 1, nestedState);
                 }
             } else {
                 const weight = Math.random();
@@ -392,66 +392,66 @@ class PoolingLayer extends Layer {
     /**
      * 
      * @param {Object} options 
-     * @param {Number} options.spatial_extent
-     * @param {Layer} options.in_layer
+     * @param {Number} options.spatialExtent
+     * @param {Layer} options.inLayer
      * @param {Net} options.net
      */
-    constructor({ spatial_extent, in_layer, net }) {
+    constructor({ spatialExtent, inLayer, net }) {
         const rectifier = null;
-        super({ in_layer, net, rectifier });
+        super({ inLayer, net, rectifier });
 
-        if (!spatial_extent || !(Number.isInteger(spatial_extent)) || spatial_extent < 2) {
-            throw new Error('spatial_extent must be an integer greater than 1');
+        if (!spatialExtent || !(Number.isInteger(spatialExtent)) || spatialExtent < 2) {
+            throw new Error('spatialExtent must be an integer greater than 1');
         }
 
         this.architecture = this.createPoolingArchitecture({ 
-            input_architecture: in_layer.architecture,
-            spatial_extent
+            inputArchitecture: inLayer.architecture,
+            spatialExtent
         });
 
         this.createConnections({
-            in_layer,
-            spatial_extent,
+            inLayer,
+            spatialExtent,
         });
     }
 
     /**
      * Creates connections
      * @param {Object} options 
-     * @param {Layer} options.in_layer
-     * @param {Number} options.spatial_extent 
+     * @param {Layer} options.inLayer
+     * @param {Number} options.spatialExtent 
      */
-    createConnections({ in_layer, spatial_extent }) {
+    createConnections({ inLayer, spatialExtent }) {
         const that = this;
         this.neuronsByState = {};
-        const input_filters = in_layer.filters.length;
+        const inputFilters = inLayer.filters.length;
 
         /**
          * 
          * @param {Object} options 
          * @param {String} options.state
-         * @param {Number} options.filter_no
+         * @param {Number} options.filterNumber
          */
-        function getInputStates({ state, filter_no }) {
-            const base_state = state.split('.');
-            base_state[0] *= spatial_extent;
-            base_state[1] *= spatial_extent;
+        function getInputStates({ state, filterNumber }) {
+            const baseState = state.split('.');
+            baseState[0] *= spatialExtent;
+            baseState[1] *= spatialExtent;
 
-            const neuron_ids = [];
-            let new_state;
+            const neuronStates = [];
+            let newState;
 
-            for (let i = 0; i < spatial_extent; i++) {
-                // copy base_state
-                new_state = base_state.slice();
-                new_state[0] += i;
-                for (let j = 0; j < spatial_extent; j++) {
-                    new_state[1] += j;
-                    const neuron_id = `${filter_no}x${new_state.join('.')}`;
-                    neuron_ids.push(neuron_id);
+            for (let i = 0; i < spatialExtent; i++) {
+                // copy baseState
+                newState = baseState.slice();
+                newState[0] += i;
+                for (let j = 0; j < spatialExtent; j++) {
+                    newState[1] += j;
+                    const neuronState = `${filterNumber}x${newState.join('.')}`;
+                    neuronStates.push(neuronState);
                 }
             }
 
-            return neuron_ids;
+            return neuronStates;
         }
 
         /**
@@ -463,35 +463,35 @@ class PoolingLayer extends Layer {
             index = index || 0;
             if (index < that.architecture.length) {
                 for (let i = 0; i < that.architecture[index]; i++) {
-                    const nested_state = state ? [state, i].join('.'): String(i);
-                    nest(index + 1, nested_state);
+                    const nestedState = state ? [state, i].join('.'): String(i);
+                    nest(index + 1, nestedState);
                 }
             } else {
-                for (let filter_no = 0; filter_no < input_filters; filter_no++) {
+                for (let filterNumber = 0; filterNumber < inputFilters; filterNumber++) {
                     const neuron = new Neuron({
                         layer: that,
                         pooling: true
                     });
 
-                    const input_states = getInputStates({ input_filters, state, filter_no });
+                    const inputStates = getInputStates({ inputFilters, state, filterNumber });
 
-                    input_states.forEach((input_state) => {
-                        const in_neuron = in_layer.neuronsByState[input_state];
+                    inputStates.forEach((inputState) => {
+                        const inNeuron = inLayer.neuronsByState[inputState];
 
                         // connection must have weight 1 for error to propagate
                         const connection = new Connection({
-                            out_neuron: neuron,
+                            outNeuron: neuron,
                             weight: 1,
-                            in_neuron
+                            inNeuron
                         });
 
                         // update on both ends of the connection
-                        neuron.connections.in[in_neuron._id] = connection;
-                        in_neuron.connections.out[neuron._id] = connection;
+                        neuron.connections.in[inNeuron._id] = connection;
+                        inNeuron.connections.out[neuron._id] = connection;
                     });
 
-                    const neuron_state = `${filter_no}x${state}`;
-                    that.neuronsByState[neuron_state] = neuron;
+                    const neuronState = `${filterNumber}x${state}`;
+                    that.neuronsByState[neuronState] = neuron;
                 }
             }
         }
@@ -502,22 +502,22 @@ class PoolingLayer extends Layer {
     /**
      * 
      * @param {Object} options
-     * @param {Array<Number>} options.input_architecture
-     * @param {Number} options.spatial_extent
+     * @param {Array<Number>} options.inputArchitecture
+     * @param {Number} options.spatialExtent
      */
-    createPoolingArchitecture({ input_architecture, spatial_extent }) {
+    createPoolingArchitecture({ inputArchitecture, spatialExtent }) {
         const architecture = [];
 
-        for (let i = 0; i < input_architecture.length; i++) {
+        for (let i = 0; i < inputArchitecture.length; i++) {
             if (i <= 1) {
-                const dimension = input_architecture[i] / spatial_extent;
+                const dimension = inputArchitecture[i] / spatialExtent;
                 if (!Number.isInteger(dimension)) {
-                    const reason = `${input_architecture[i]} % ${spatial_extent} = ${dimension}`;
+                    const reason = `${inputArchitecture[i]} % ${spatialExtent} = ${dimension}`;
                     throw new Error(`Pooling extent not compatible with input architecture! ${reason}`);
                 }
                 architecture.push(dimension);
             } else {
-                architecture.push(input_architecture[i]);
+                architecture.push(inputArchitecture[i]);
             }
         }
         return architecture;

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -179,19 +179,16 @@ class ConvolutionalLayer extends Layer {
         // only fully-connected layers can be input layer
         super({ inLayer, net, rectifier });
         this.filters = [];
+        this.filterArchitecture = filterArchitecture;
+        this.stride = stride;
 
         for (let i = 0; i < depth; i++) {
-            const filter = this.createFilterFromArchitecture({
-                architecture: filterArchitecture
-            });
+            const filter = this.createFilterFromArchitecture();
 
             this.filters.push(filter);
         }
 
-        this.architecture = this.generateArchitecture({
-            filterArchitecture,
-            stride,
-        });
+        this.architecture = this.generateArchitecture();
 
         const that = this;
 
@@ -220,9 +217,7 @@ class ConvolutionalLayer extends Layer {
                 that.createConnections({
                     neuron: that.neuronsByState[state],
                     neuronState: state.split('x')[1],
-                    filterArchitecture,
                     filterNumber,
-                    stride,
                 }); 
             }
         }
@@ -235,22 +230,19 @@ class ConvolutionalLayer extends Layer {
 
     /**
      * Calculates architecture based on parameters
-     * @param {Object} options 
-     * @param {Array<Number>} filterArchitecture
-     * @param {Number} stride
      */
-    generateArchitecture({ filterArchitecture, stride }) {
+    generateArchitecture() {
         const architecture = [];
         for (let j = 0; j < this.inLayer.architecture.length; j++) {
             const dimension = this.inLayer.architecture[j];
-            const numNeurons = (dimension - (filterArchitecture[j] - stride)) / stride;
+            const numNeurons = (dimension - (this.filterArchitecture[j] - this.stride)) / this.stride;
 
             if (!numNeurons || !Number.isInteger(numNeurons) || numNeurons < 1) {
                 throw errors.errors.INCOMPATIBLE_FILTER({
                     inputLength: dimension,
-                    filterLength: filterArchitecture[j],
+                    filterLength: this.filterArchitecture[j],
                     res: numNeurons,
-                    stride,
+                    stride: this.stride,
                 });
             }
             architecture.push(numNeurons);
@@ -292,12 +284,10 @@ class ConvolutionalLayer extends Layer {
      * Creates connections to other layer
      * @param {Object} options
      * @param {Neuron} options.neuron
-     * @param {Array<Number>} options.filterArchitecture
      * @param {Number} options.filterNumber
      * @param {String} options.neuronState
-     * @param {Number} options.stride
      */
-    createConnections({ neuron, filterArchitecture, filterNumber, neuronState, stride }) {
+    createConnections({ neuron, filterNumber, neuronState }) {
         const numInFilters = this.inLayer.filters ? this.inLayer.filters.length : 0;
         const that = this;
 
@@ -308,8 +298,8 @@ class ConvolutionalLayer extends Layer {
          */
         function nest(index, state) {
             index = index || 0;
-            if (index < filterArchitecture.length) {
-                for (let i = 0; i < filterArchitecture[index]; i++) {
+            if (index < that.filterArchitecture.length) {
+                for (let i = 0; i < that.filterArchitecture[index]; i++) {
                     const nestedState = state ? [state, i].join('.'): String(i);
                     nest(index + 1, nestedState);
                 }
@@ -319,7 +309,7 @@ class ConvolutionalLayer extends Layer {
 
                 const inNeuronCoords = [];
                 for (let j = 0; j < neuronCoords.length; j++) {
-                    const coord = parseInt(neuronCoords[j], 10) * stride + parseInt(connectionCoords[j], 10);
+                    const coord = parseInt(neuronCoords[j], 10) * that.stride + parseInt(connectionCoords[j], 10);
                     inNeuronCoords.push(coord);
                 }
 
@@ -338,10 +328,9 @@ class ConvolutionalLayer extends Layer {
 
     /**
      * Creates filter based on structure
-     * @param {Object} options 
-     * @param {Array<Number>} options.architecture
      */
-    createFilterFromArchitecture({ architecture }) {
+    createFilterFromArchitecture() {
+        const that = this;
         let sum = 0;
         const connectionParamsByState = {};
 
@@ -352,8 +341,8 @@ class ConvolutionalLayer extends Layer {
          */
         function nest(index, state) {
             index = index || 0;
-            if (index < architecture.length) {
-                for (let i = 0; i < architecture[index]; i++) {
+            if (index < that.filterArchitecture.length) {
+                for (let i = 0; i < that.filterArchitecture[index]; i++) {
                     const nestedState = state ? [state, i].join('.'): String(i);
                     nest(index + 1, nestedState);
                 }
@@ -389,28 +378,21 @@ class PoolingLayer extends Layer {
      * @param {Net} options.net
      */
     constructor({ spatialExtent, inLayer, net }) {
-        const rectifier = null;
-        super({ inLayer, net, rectifier });
+        super({ inLayer, net, rectifier: null });
+        this.spatialExtent = spatialExtent;
 
         if (!spatialExtent || !(Number.isInteger(spatialExtent)) || spatialExtent < 2) {
             throw new Error('spatialExtent must be an integer greater than 1');
         }
 
-        this.architecture = this.createPoolingArchitecture({ 
-            spatialExtent
-        });
-
-        this.createConnections({
-            spatialExtent,
-        });
+        this.architecture = this.createPoolingArchitecture();
+        this.createConnections();
     }
 
     /**
      * Creates connections
-     * @param {Object} options 
-     * @param {Number} options.spatialExtent 
      */
-    createConnections({ spatialExtent }) {
+    createConnections() {
         const that = this;
         const inputFilters = this.inLayer.filters.length;
 
@@ -422,17 +404,17 @@ class PoolingLayer extends Layer {
          */
         function getInputStates({ state, filterNumber }) {
             const baseState = state.split('.');
-            baseState[0] *= spatialExtent;
-            baseState[1] *= spatialExtent;
+            baseState[0] *= that.spatialExtent;
+            baseState[1] *= that.spatialExtent;
 
             const neuronStates = [];
             let newState;
 
-            for (let i = 0; i < spatialExtent; i++) {
+            for (let i = 0; i < that.spatialExtent; i++) {
                 // copy baseState
                 newState = baseState.slice();
                 newState[0] += i;
-                for (let j = 0; j < spatialExtent; j++) {
+                for (let j = 0; j < that.spatialExtent; j++) {
                     newState[1] += j;
                     const neuronState = `${filterNumber}x${newState.join('.')}`;
                     neuronStates.push(neuronState);
@@ -488,19 +470,17 @@ class PoolingLayer extends Layer {
     }
 
     /**
-     * 
-     * @param {Object} options
-     * @param {Number} options.spatialExtent
+     * Calculates architecture for pooling layer based on input layer and spatial extent
      */
-    createPoolingArchitecture({ spatialExtent }) {
+    createPoolingArchitecture() {
         const architecture = [];
 
         for (let i = 0; i < this.inLayer.architecture.length; i++) {
             const inputDimension = this.inLayer.architecture[i];
             if (i <= 1) {
-                const dimension = inputDimension / spatialExtent;
+                const dimension = inputDimension / this.spatialExtent;
                 if (!Number.isInteger(dimension)) {
-                    const reason = `${inputDimension} % ${spatialExtent} = ${dimension}`;
+                    const reason = `${inputDimension} % ${this.spatialExtent} = ${dimension}`;
                     throw new Error(`Pooling extent not compatible with input architecture! ${reason}`);
                 }
                 architecture.push(dimension);

--- a/lib/net.js
+++ b/lib/net.js
@@ -25,27 +25,27 @@ class Net {
      * 
      * @param {Object} options 
      * @param {Array<Number>} options.architecture
-     * @param {Number} options.learning_rate
+     * @param {Number} options.learningRate
      */
-    constructor({ input_architecture, layer_configs, learning_rate }) {
-        this.learning_rate = learning_rate;
+    constructor({ inputArchitecture, layerConfigs, learningRate }) {
+        this.learningRate = learningRate;
         this.predictions = 0;
         this.successes = 0;
         this.logPower = 1;
 
         this.layers = [
             new FullyConnectedLayer({
-                is_input: true,
+                isInput: true,
                 net: this,
-                architecture: input_architecture,
+                architecture: inputArchitecture,
             })
         ];
 
-        for (let i = 0; i < layer_configs.length; i++) {
-            const layerConfig = layer_configs[i];
+        for (let i = 0; i < layerConfigs.length; i++) {
+            const layerConfig = layerConfigs[i];
             const options = {
                 net: this,
-                in_layer: this.finalLayer,
+                inLayer: this.finalLayer,
                 ...layerConfig.options
             };
 
@@ -72,7 +72,7 @@ class Net {
      * fetches all layers which are not the input layer
      * @return {Array<Layer>}
      */
-    get input_layer() {
+    get inputLayer() {
         return this.layers[0];
     }
 
@@ -80,7 +80,7 @@ class Net {
      * fetches all layers which are not the input layer
      * @return {Array<Layer>}
      */
-    get non_input_layers() {
+    get nonInputLayers() {
         return this.layers.slice(1, this.layers.length);
     }
 
@@ -89,27 +89,27 @@ class Net {
      * @param {Array<Number>} input 
      */
     assignInputActivations(input) {
-        const input_layer = this.input_layer;
+        const inputLayer = this.inputLayer;
 
         /**
          * Recursive function to assign activations
          * @param {} arch 
-         * @param {*} arr_or_value 
+         * @param {*} arrOrValue 
          * @param {*} index 
          * @param {*} state 
          */
-        function nest(arr_or_value, index, state) {
+        function nest(arrOrValue, index, state) {
             index = index || 0;
-            if (index < input_layer.architecture.length) {
+            if (index < inputLayer.architecture.length) {
                 // nest through dimensions
-                for (var i = 0; i < input_layer.architecture[index]; i++) {
-                    const nested_state = state ? [state, i].join('.'): String(i);
-                    const nested_arr = arr_or_value[i];
-                    nest(nested_arr, index + 1, nested_state);
+                for (var i = 0; i < inputLayer.architecture[index]; i++) {
+                    const nestedState = state ? [state, i].join('.'): String(i);
+                    const nestedArr = arrOrValue[i];
+                    nest(nestedArr, index + 1, nestedState);
                 }
             } else {
                 // assign value to neuron
-                input_layer.neuronsByState[state].activation = arr_or_value;
+                inputLayer.neuronsByState[state].activation = arrOrValue;
             }
         }
 
@@ -135,8 +135,8 @@ class Net {
      * @return {Array<Number>} returns final prediction
      */
     activate() {
-        for (var i = 0; i < this.non_input_layers.length; i++) {
-            this.non_input_layers[i].activate();
+        for (var i = 0; i < this.nonInputLayers.length; i++) {
+            this.nonInputLayers[i].activate();
         }
 
         return this.finalLayer.activate();
@@ -149,8 +149,8 @@ class Net {
     backPropagate(target) {
         this.finalLayer.propagate(target);
 
-        for (var i = this.non_input_layers.length - 2; i >= 0; i--) {
-            this.non_input_layers[i].propagate();
+        for (var i = this.nonInputLayers.length - 2; i >= 0; i--) {
+            this.nonInputLayers[i].propagate();
         }
     }
 
@@ -192,8 +192,8 @@ class Net {
 
         return Promise.all(
             fs.readdirSync(directory)
-                .filter((file_name) => file_name[0] !== '.')
-                .map((file_name) => net.loadImage(`${directory}/${file_name}`)))
+                .filter((fileName) => fileName[0] !== '.')
+                .map((fileName) => net.loadImage(`${directory}/${fileName}`)))
             .catch((err) => {
                 console.log('err:', err);
             });
@@ -201,24 +201,24 @@ class Net {
 
     /**
      * Loads an image
-     * @param {String} file_path 
+     * @param {String} filePath 
      */
-    loadImage(file_path) {
+    loadImage(filePath) {
         return new Promise((resolve) => {
             const arr = [];
-            fs.createReadStream(file_path)
+            fs.createReadStream(filePath)
             .pipe(new PNG({ filterType: 4 }))
             .on('parsed', function() {
-                console.log(`Parsed ${file_path}!`);
+                console.log(`Parsed ${filePath}!`);
                 for (var x = 0; x < this.width; x++) {
                     arr.push([]);
                     for (var y = 0; y < this.height; y++) {
                         arr[x].push([]);
                         for (var z = 0; z < 3; z++) {
-                            const pixel_id = ((this.width * y + x) << 2) + z;
-                            const pixel_value = this.data[pixel_id];
+                            const pixelId = ((this.width * y + x) << 2) + z;
+                            const pixelValue = this.data[pixelId];
                             // const state = [x, y, z].join('.');
-                            arr[x][y].push(pixel_value);
+                            arr[x][y].push(pixelValue);
                         }
                     }
                 }

--- a/lib/net.js
+++ b/lib/net.js
@@ -109,7 +109,7 @@ class Net {
                 }
             } else {
                 // assign value to neuron
-                input_layer.neurons[state].activation = arr_or_value;
+                input_layer.neuronsByState[state].activation = arr_or_value;
             }
         }
 

--- a/lib/neuron.js
+++ b/lib/neuron.js
@@ -24,19 +24,19 @@ class Connection {
     /**
      * 
      * @param {Object} options
-     * @param {Neuron} options.in_neuron 
-     * @param {Neuron} options.out_neuron 
+     * @param {Neuron} options.inNeuron 
+     * @param {Neuron} options.outNeuron 
      * @param {Number} options.weight 
-     * @param {ConnectionParams} options.shared_params 
+     * @param {ConnectionParams} options.sharedParams 
      */
-    constructor({ in_neuron, out_neuron, weight, shared_params }) {
-        this.in_neuron = in_neuron;
-        this.out_neuron = out_neuron;
+    constructor({ inNeuron, outNeuron, weight, sharedParams }) {
+        this.inNeuron = inNeuron;
+        this.outNeuron = outNeuron;
 
         if (weight) {
             this.params = new ConnectionParams(weight);
-        } else if (shared_params) {
-            this.params = shared_params;
+        } else if (sharedParams) {
+            this.params = sharedParams;
         }
     }
 }
@@ -83,9 +83,9 @@ class Neuron {
             };
 
             Object.values(this.connections.in).forEach((connection) => {
-                if (connection.in_neuron.activation > max.activation) {
-                    max.activation = connection.in_neuron.activation;
-                    max.derivative = connection.in_neuron.derivative;
+                if (connection.inNeuron.activation > max.activation) {
+                    max.activation = connection.inNeuron.activation;
+                    max.derivative = connection.inNeuron.derivative;
                 }
             });
 
@@ -94,7 +94,7 @@ class Neuron {
         } else {
             let activation = this.bias;
             Object.values(this.connections.in).forEach((connection) => {
-                activation += connection.in_neuron.activation * connection.params.weight;
+                activation += connection.inNeuron.activation * connection.params.weight;
             });
         
             this.activation = this.layer.rectifier(activation, false);
@@ -113,18 +113,18 @@ class Neuron {
             let error = 0;
 
             Object.values(this.connections.out).forEach((connection) => {
-                error += connection.out_neuron.error * connection.params.weight;
+                error += connection.outNeuron.error * connection.params.weight;
             });
             this.error = this.derivative * error;
         }
 
         // LEARN
         Object.values(this.connections.in).forEach((connection) => {
-            const gradient = this.error * connection.in_neuron.activation;
-            connection.params.weight += this.layer.net.learning_rate * gradient;
+            const gradient = this.error * connection.inNeuron.activation;
+            connection.params.weight += this.layer.net.learningRate * gradient;
         });
 
-        this.bias += this.layer.net.learning_rate * this.error;
+        this.bias += this.layer.net.learningRate * this.error;
     }
 }
 

--- a/lib/neuron.js
+++ b/lib/neuron.js
@@ -58,47 +58,18 @@ class Neuron {
     /**
      * 
      * @param {Object} options 
-     * @param {Array<Neuron>} options.in_neurons
      * @param {Layer} options.layer
      * @param {Boolean} options.pooling
      */
-    constructor({ in_neurons, layer, pooling }) {
+    constructor({ layer, pooling = false }) {
         this._id = Neuron.uuid();
         this.layer = layer;
         this.pooling = pooling;
         this.bias = 0;
-
         this.connections = {
             out: {},
             in: {}
         };
-
-        // create connections to all neurons in input layer
-        if (in_neurons) {
-            let sum = 0;
-            this.bias = 0;
-
-            Object.values(in_neurons).forEach((neuron) => {
-                const weight = Math.random();
-                sum += weight;
-
-                const connection = new Connection({
-                    in_neuron: neuron,
-                    out_neuron: this,
-                    weight
-                });
-
-                // update on both ends of the connection
-                this.connections.in[neuron._id] = connection;
-                neuron.connections.out[this._id] = connection;
-            });
-
-            // ensure that all weights add to 1
-            const multiplier = 1 / sum;
-            Object.values(this.connections.in).forEach((connection) => {
-                connection.params.weight *= multiplier;
-            });
-        }
     }
 
     /**

--- a/specs/convolutionalLayer.spec.js
+++ b/specs/convolutionalLayer.spec.js
@@ -10,13 +10,13 @@ describe('Convolutional Layers', () => {
         describe('can be created', () => {
             it('when filter has same number of dimensions as input layer', () => {
                 const net = new Net({
-                    input_architecture: [3, 3, 3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3, 3, 3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [3, 3, 3],
+                                filterArchitecture: [3, 3, 3],
                                 depth: 1,
                                 stride: 1,
                                 rectifier: rectifiers.relu,
@@ -30,13 +30,13 @@ describe('Convolutional Layers', () => {
 
             it('when filter is smaller than the input layer', () => {
                 const net = new Net({
-                    input_architecture: [3, 3, 3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3, 3, 3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [1, 1, 1],
+                                filterArchitecture: [1, 1, 1],
                                 depth: 1,
                                 stride: 1,
                                 rectifier: rectifiers.relu,
@@ -49,13 +49,13 @@ describe('Convolutional Layers', () => {
 
             it('with multiple filters', () => {
                 const net = new Net({
-                    input_architecture: [3, 3, 3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3, 3, 3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [3, 3, 3],
+                                filterArchitecture: [3, 3, 3],
                                 depth: 6,
                                 stride: 1,
                                 rectifier: rectifiers.relu,
@@ -69,13 +69,13 @@ describe('Convolutional Layers', () => {
 
             it('with stride > 1', () => {
                 const net = new Net({
-                    input_architecture: [6, 6, 3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [6, 6, 3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [3, 3, 3],
+                                filterArchitecture: [3, 3, 3],
                                 depth: 1,
                                 stride: 3,
                                 rectifier: rectifiers.relu,
@@ -90,16 +90,16 @@ describe('Convolutional Layers', () => {
 
         describe('cannot be created', () => {
             it('with filter larger than input', () => {
-                let error_thrown = false;
+                let errorThrown = false;
                 try {
                     new Net({
-                        input_architecture: [3, 3, 3],
-                        learning_rate: 0.02,
-                        layer_configs: [
+                        inputArchitecture: [3, 3, 3],
+                        learningRate: 0.02,
+                        layerConfigs: [
                             {
                                 type: 'CONVOLUTIONAL',
                                 options: {
-                                    filter_architecture: [4, 4, 3],
+                                    filterArchitecture: [4, 4, 3],
                                     depth: 1,
                                     stride: 1,
                                     rectifier: rectifiers.relu,
@@ -108,25 +108,25 @@ describe('Convolutional Layers', () => {
                         ]
                     });
                 } catch(err) {
-                    error_thrown = true;
+                    errorThrown = true;
                     expect(err.code).to.equal(errors.codes.INCOMPATIBLE_FILTER);
                 }
 
-                expect(error_thrown).to.be.true;
+                expect(errorThrown).to.be.true;
             });
 
             it('with stride that pushes filter beyond input', () => {
-                let error_thrown = false;
+                let errorThrown = false;
 
                 try {
                     new Net({
-                        input_architecture: [3, 3, 3],
-                        learning_rate: 0.02,
-                        layer_configs: [
+                        inputArchitecture: [3, 3, 3],
+                        learningRate: 0.02,
+                        layerConfigs: [
                             {
                                 type: 'CONVOLUTIONAL',
                                 options: {
-                                    filter_architecture: [2, 2, 2],
+                                    filterArchitecture: [2, 2, 2],
                                     depth: 1,
                                     stride: 2,
                                     rectifier: rectifiers.relu,
@@ -135,11 +135,11 @@ describe('Convolutional Layers', () => {
                         ]
                     });
                 } catch(err) {
-                    error_thrown = true;
+                    errorThrown = true;
                     expect(err.code).to.equal(errors.codes.INCOMPATIBLE_FILTER);
                 }
 
-                expect(error_thrown).to.be.true;
+                expect(errorThrown).to.be.true;
             });
         });
     });
@@ -148,13 +148,13 @@ describe('Convolutional Layers', () => {
         describe('can be created', () => {
             it('when filter has same number of dimensions as input layer', () => {
                 const net = new Net({
-                    input_architecture: [7, 7, 7],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [7, 7, 7],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [4, 4, 4],
+                                filterArchitecture: [4, 4, 4],
                                 depth: 1,
                                 stride: 1,
                                 rectifier: rectifiers.relu,
@@ -163,7 +163,7 @@ describe('Convolutional Layers', () => {
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [3, 3, 3],
+                                filterArchitecture: [3, 3, 3],
                                 depth: 1,
                                 stride: 1,
                                 rectifier: rectifiers.relu,
@@ -177,13 +177,13 @@ describe('Convolutional Layers', () => {
 
             it('when filter is smaller than the input layer', () => {
                 const net = new Net({
-                    input_architecture: [7, 7, 7],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [7, 7, 7],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [4, 4, 4],
+                                filterArchitecture: [4, 4, 4],
                                 depth: 1,
                                 stride: 1,
                                 rectifier: rectifiers.relu,
@@ -192,7 +192,7 @@ describe('Convolutional Layers', () => {
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [1, 1, 1],
+                                filterArchitecture: [1, 1, 1],
                                 depth: 1,
                                 stride: 1,
                                 rectifier: rectifiers.relu,
@@ -206,13 +206,13 @@ describe('Convolutional Layers', () => {
 
             it('with multiple filters', () => {
                 const net = new Net({
-                    input_architecture: [7, 7, 7],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [7, 7, 7],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [4, 4, 4],
+                                filterArchitecture: [4, 4, 4],
                                 depth: 1,
                                 stride: 1,
                                 rectifier: rectifiers.relu,
@@ -221,7 +221,7 @@ describe('Convolutional Layers', () => {
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [3, 3, 3],
+                                filterArchitecture: [3, 3, 3],
                                 depth: 6,
                                 stride: 1,
                                 rectifier: rectifiers.relu,
@@ -235,13 +235,13 @@ describe('Convolutional Layers', () => {
 
             it('with stride > 1', () => {
                 const net = new Net({
-                    input_architecture: [6, 6, 3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [6, 6, 3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [1, 1, 1],
+                                filterArchitecture: [1, 1, 1],
                                 depth: 1,
                                 stride: 1,
                                 rectifier: rectifiers.relu,
@@ -250,7 +250,7 @@ describe('Convolutional Layers', () => {
                         {
                             type: 'CONVOLUTIONAL',
                             options: {
-                                filter_architecture: [3, 3, 3],
+                                filterArchitecture: [3, 3, 3],
                                 depth: 1,
                                 stride: 3,
                                 rectifier: rectifiers.relu,
@@ -264,17 +264,17 @@ describe('Convolutional Layers', () => {
         });
         describe('cannot be created', () => {
             it('with filter larger than input', () => {
-                let error_thrown = false;
+                let errorThrown = false;
 
                 try {
                     new Net({
-                        input_architecture: [7, 7, 7],
-                        learning_rate: 0.02,
-                        layer_configs: [
+                        inputArchitecture: [7, 7, 7],
+                        learningRate: 0.02,
+                        layerConfigs: [
                             {
                                 type: 'CONVOLUTIONAL',
                                 options: {
-                                    filter_architecture: [4, 4, 4],
+                                    filterArchitecture: [4, 4, 4],
                                     depth: 1,
                                     stride: 1,
                                     rectifier: rectifiers.relu,
@@ -283,7 +283,7 @@ describe('Convolutional Layers', () => {
                             {
                                 type: 'CONVOLUTIONAL',
                                 options: {
-                                    filter_architecture: [5, 5, 3],
+                                    filterArchitecture: [5, 5, 3],
                                     depth: 1,
                                     stride: 1,
                                     rectifier: rectifiers.relu,
@@ -292,24 +292,24 @@ describe('Convolutional Layers', () => {
                         ]
                     });
                 } catch(err) {
-                    error_thrown = true;
+                    errorThrown = true;
                     expect(err.code).to.equal(errors.codes.INCOMPATIBLE_FILTER);
                 }
-                expect(error_thrown).to.be.true;
+                expect(errorThrown).to.be.true;
             });
 
             it('with stride that pushes filter beyond input', () => {
-                let error_thrown = false;
+                let errorThrown = false;
 
                 try {
                     new Net({
-                        input_architecture: [7, 7, 7],
-                        learning_rate: 0.02,
-                        layer_configs: [
+                        inputArchitecture: [7, 7, 7],
+                        learningRate: 0.02,
+                        layerConfigs: [
                             {
                                 type: 'CONVOLUTIONAL',
                                 options: {
-                                    filter_architecture: [4, 4, 4],
+                                    filterArchitecture: [4, 4, 4],
                                     depth: 1,
                                     stride: 1,
                                     rectifier: rectifiers.relu,
@@ -318,7 +318,7 @@ describe('Convolutional Layers', () => {
                             {
                                 type: 'CONVOLUTIONAL',
                                 options: {
-                                    filter_architecture: [2, 2, 2],
+                                    filterArchitecture: [2, 2, 2],
                                     depth: 1,
                                     stride: 3,
                                     rectifier: rectifiers.relu,
@@ -327,11 +327,11 @@ describe('Convolutional Layers', () => {
                         ]
                     });
                 } catch(err) {
-                    error_thrown = true;
+                    errorThrown = true;
                     expect(err.code).to.equal(errors.codes.INCOMPATIBLE_FILTER);
                 }
 
-                expect(error_thrown).to.be.true;
+                expect(errorThrown).to.be.true;
             });
         });
     });
@@ -339,13 +339,13 @@ describe('Convolutional Layers', () => {
     describe('backpropagation:', () => {
         it('all activations are numbers', () => {
             const net = new Net({
-                input_architecture: [9, 9, 3],
-                learning_rate: 0.0000002,
-                layer_configs: [
+                inputArchitecture: [9, 9, 3],
+                learningRate: 0.0000002,
+                layerConfigs: [
                     {
                         type: 'CONVOLUTIONAL',
                         options: {
-                            filter_architecture: [4, 4, 3],
+                            filterArchitecture: [4, 4, 3],
                             depth: 3,
                             stride: 1,
                             rectifier: rectifiers.relu,
@@ -365,27 +365,27 @@ describe('Convolutional Layers', () => {
             .then((image) => {
                 net.learn(image, [0, 1]);
 
-                let all_numbers = true;
+                let allNumbers = true;
 
                 Object.values(net.layers[0].neuronsByState).forEach((neuron) => {
                     if (typeof neuron.activation !== 'number') {
-                        all_numbers = false;
+                        allNumbers = false;
                     }
                 });
 
-                expect(all_numbers).to.be.true;
+                expect(allNumbers).to.be.true;
             });
         });
 
         it('all activations are not zero', () => {
             const net = new Net({
-                input_architecture: [9, 9, 3],
-                learning_rate: 0.0000002,
-                layer_configs: [
+                inputArchitecture: [9, 9, 3],
+                learningRate: 0.0000002,
+                layerConfigs: [
                     {
                         type: 'CONVOLUTIONAL',
                         options: {
-                            filter_architecture: [4, 4, 3],
+                            filterArchitecture: [4, 4, 3],
                             depth: 3,
                             stride: 1,
                             rectifier: rectifiers.relu,
@@ -407,27 +407,27 @@ describe('Convolutional Layers', () => {
                     net.learn(image, [Math.random(), Math.random()]);
                 }
 
-                let all_zeroes = true;
+                let allZeroes = true;
 
                 Object.values(net.layers[0].neuronsByState).forEach((neuron) => {
                     if (neuron.activation !== 0) {
-                        all_zeroes = false;
+                        allZeroes = false;
                     }
                 });
 
-                expect(all_zeroes).to.be.false;
+                expect(allZeroes).to.be.false;
             });
         });
 
         it('predictions are numbers', () => {
             const net = new Net({
-                input_architecture: [9, 9, 3],
-                learning_rate: 0.0000002,
-                layer_configs: [
+                inputArchitecture: [9, 9, 3],
+                learningRate: 0.0000002,
+                layerConfigs: [
                     {
                         type: 'CONVOLUTIONAL',
                         options: {
-                            filter_architecture: [4, 4, 3],
+                            filterArchitecture: [4, 4, 3],
                             depth: 3,
                             stride: 1,
                             rectifier: rectifiers.relu,
@@ -451,11 +451,11 @@ describe('Convolutional Layers', () => {
 
                 const prediction = net.predict(image, [Math.random(), Math.random()]);
                 console.log(prediction);
-                const are_numbers = typeof prediction[0] === 'number' && typeof prediction[1] === 'number';
-                const are_not_NaN = (Boolean(prediction[0]) || prediction[0] === 0) &&
+                const areNumbers = typeof prediction[0] === 'number' && typeof prediction[1] === 'number';
+                const areNotNaN = (Boolean(prediction[0]) || prediction[0] === 0) &&
                     (Boolean(prediction[1]) || prediction[1] === 0);
-                expect(are_numbers).to.be.true;
-                expect(are_not_NaN).to.be.true;
+                expect(areNumbers).to.be.true;
+                expect(areNotNaN).to.be.true;
             });
         });
     });

--- a/specs/convolutionalLayer.spec.js
+++ b/specs/convolutionalLayer.spec.js
@@ -367,7 +367,7 @@ describe('Convolutional Layers', () => {
 
                 let allNumbers = true;
 
-                Object.values(net.layers[0].neuronsByState).forEach((neuron) => {
+                Object.values(net.inputLayer.neuronsByState).forEach((neuron) => {
                     if (typeof neuron.activation !== 'number') {
                         allNumbers = false;
                     }
@@ -409,7 +409,7 @@ describe('Convolutional Layers', () => {
 
                 let allZeroes = true;
 
-                Object.values(net.layers[0].neuronsByState).forEach((neuron) => {
+                Object.values(net.inputLayer.neuronsByState).forEach((neuron) => {
                     if (neuron.activation !== 0) {
                         allZeroes = false;
                     }

--- a/specs/convolutionalLayer.spec.js
+++ b/specs/convolutionalLayer.spec.js
@@ -25,7 +25,7 @@ describe('Convolutional Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(1);
+                expect(net.finalLayer.states).to.have.length(1);
             });
 
             it('when filter is smaller than the input layer', () => {
@@ -44,7 +44,7 @@ describe('Convolutional Layers', () => {
                         }
                     ]
                 });
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(27);
+                expect(net.finalLayer.states).to.have.length(27);
             });
 
             it('with multiple filters', () => {
@@ -64,7 +64,7 @@ describe('Convolutional Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(6);
+                expect(net.finalLayer.states).to.have.length(6);
             });
 
             it('with stride > 1', () => {
@@ -84,7 +84,7 @@ describe('Convolutional Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(4);
+                expect(net.finalLayer.states).to.have.length(4);
             });
         });
 
@@ -172,7 +172,7 @@ describe('Convolutional Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(8);
+                expect(net.finalLayer.states).to.have.length(8);
             });
 
             it('when filter is smaller than the input layer', () => {
@@ -201,7 +201,7 @@ describe('Convolutional Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(64);
+                expect(net.finalLayer.states).to.have.length(64);
             });
 
             it('with multiple filters', () => {
@@ -230,7 +230,7 @@ describe('Convolutional Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(48);
+                expect(net.finalLayer.states).to.have.length(48);
             });
 
             it('with stride > 1', () => {
@@ -259,7 +259,7 @@ describe('Convolutional Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(4);
+                expect(net.finalLayer.states).to.have.length(4);
             });
         });
         describe('cannot be created', () => {
@@ -367,7 +367,7 @@ describe('Convolutional Layers', () => {
 
                 let all_numbers = true;
 
-                Object.values(net.layers[0].neurons).forEach((neuron) => {
+                Object.values(net.layers[0].neuronsByState).forEach((neuron) => {
                     if (typeof neuron.activation !== 'number') {
                         all_numbers = false;
                     }
@@ -409,7 +409,7 @@ describe('Convolutional Layers', () => {
 
                 let all_zeroes = true;
 
-                Object.values(net.layers[0].neurons).forEach((neuron) => {
+                Object.values(net.layers[0].neuronsByState).forEach((neuron) => {
                     if (neuron.activation !== 0) {
                         all_zeroes = false;
                     }

--- a/specs/fullyConnectedLayer.spec.js
+++ b/specs/fullyConnectedLayer.spec.js
@@ -14,7 +14,7 @@ describe('Fully Connected Layers', () => {
                     layerConfigs: [],
                 });
 
-                expect(net.layers[0].states).to.have.length(3);
+                expect(net.inputLayer.states).to.have.length(3);
             });
 
             it('with two-dimensional architecture', () => {
@@ -24,7 +24,7 @@ describe('Fully Connected Layers', () => {
                     layerConfigs: [],
                 });
 
-                expect(net.layers[0].states).to.have.length(12);
+                expect(net.inputLayer.states).to.have.length(12);
             });
 
             it('with three-dimensional architecture', () => {
@@ -33,7 +33,7 @@ describe('Fully Connected Layers', () => {
                     inputArchitecture: [3, 4, 5],
                     layerConfigs: [],
                 });
-                expect(net.layers[0].states).to.have.length(60);
+                expect(net.inputLayer.states).to.have.length(60);
             });
 
             it('with four-dimensional architecture', () => {
@@ -42,7 +42,7 @@ describe('Fully Connected Layers', () => {
                     inputArchitecture: [3, 4, 5, 6],
                     layerConfigs: [],
                 });
-                expect(net.layers[0].states).to.have.length(360);
+                expect(net.inputLayer.states).to.have.length(360);
             });
         });
 
@@ -339,8 +339,8 @@ describe('Fully Connected Layers', () => {
 
 
             let allNumbers = true;
-            net.layers[0].states.forEach((state) => {
-                const activation = net.layers[0].neuronsByState[state].activation;
+            net.inputLayer.states.forEach((state) => {
+                const activation = net.inputLayer.neuronsByState[state].activation;
                 if (typeof activation !== 'number') {
                     allNumbers = false;
                 }
@@ -375,8 +375,8 @@ describe('Fully Connected Layers', () => {
             }
 
             let allZeroes = true;
-            net.layers[0].states.forEach((state) => {
-                const activation = net.layers[0].neuronsByState[state].activation;
+            net.inputLayer.states.forEach((state) => {
+                const activation = net.inputLayer.neuronsByState[state].activation;
                 if (activation !== 0) {
                     allZeroes = false;
                 }

--- a/specs/fullyConnectedLayer.spec.js
+++ b/specs/fullyConnectedLayer.spec.js
@@ -9,9 +9,9 @@ describe('Fully Connected Layers', () => {
         describe('can be created', () => {
             it('with one-dimensional architecture', () => {
                 const net = new Net({
-                    learning_rate: 0.02,
-                    input_architecture: [3],
-                    layer_configs: [],
+                    learningRate: 0.02,
+                    inputArchitecture: [3],
+                    layerConfigs: [],
                 });
 
                 expect(net.layers[0].states).to.have.length(3);
@@ -19,9 +19,9 @@ describe('Fully Connected Layers', () => {
 
             it('with two-dimensional architecture', () => {
                 const net = new Net({
-                    learning_rate: 0.02,
-                    input_architecture: [3, 4],
-                    layer_configs: [],
+                    learningRate: 0.02,
+                    inputArchitecture: [3, 4],
+                    layerConfigs: [],
                 });
 
                 expect(net.layers[0].states).to.have.length(12);
@@ -29,18 +29,18 @@ describe('Fully Connected Layers', () => {
 
             it('with three-dimensional architecture', () => {
                 const net = new Net({
-                    learning_rate: 0.02,
-                    input_architecture: [3, 4, 5],
-                    layer_configs: [],
+                    learningRate: 0.02,
+                    inputArchitecture: [3, 4, 5],
+                    layerConfigs: [],
                 });
                 expect(net.layers[0].states).to.have.length(60);
             });
 
             it('with four-dimensional architecture', () => {
                 const net = new Net({
-                    learning_rate: 0.02,
-                    input_architecture: [3, 4, 5, 6],
-                    layer_configs: [],
+                    learningRate: 0.02,
+                    inputArchitecture: [3, 4, 5, 6],
+                    layerConfigs: [],
                 });
                 expect(net.layers[0].states).to.have.length(360);
             });
@@ -48,21 +48,21 @@ describe('Fully Connected Layers', () => {
 
         describe('cannot be created', () => {
             it('with empty architecture', () => {
-                let error_thrown = false;
+                let errorThrown = false;
 
                 try {
                     new Net({
-                        input_architecture: [],
-                        learning_rate: 0.02,
-                        layer_configs: []
+                        inputArchitecture: [],
+                        learningRate: 0.02,
+                        layerConfigs: []
                     });
                 }
                 catch (err) {
-                    error_thrown = true;
+                    errorThrown = true;
                     expect(err.message).to.equal('Architecture must be array with at least one dimension');
                 }
 
-                expect(error_thrown).to.equal(true);
+                expect(errorThrown).to.equal(true);
             });
         });
     });
@@ -71,9 +71,9 @@ describe('Fully Connected Layers', () => {
         describe('can be created', () => {
             it('with one-dimensional architecture', () => {
                 const net = new Net({
-                    input_architecture: [3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'FULLY_CONNECTED',
                             options: {
@@ -89,9 +89,9 @@ describe('Fully Connected Layers', () => {
 
             it('with two-dimensional architecture', () => {
                 const net = new Net({
-                    input_architecture: [3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'FULLY_CONNECTED',
                             options: {
@@ -107,9 +107,9 @@ describe('Fully Connected Layers', () => {
 
             it('with three-dimensional architecture', () => {
                 const net = new Net({
-                    input_architecture: [3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'FULLY_CONNECTED',
                             options: {
@@ -125,9 +125,9 @@ describe('Fully Connected Layers', () => {
 
             it('with four-dimensional architecture', () => {
                 const net = new Net({
-                    input_architecture: [3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'FULLY_CONNECTED',
                             options: {
@@ -144,13 +144,13 @@ describe('Fully Connected Layers', () => {
 
         describe('cannot be created', () => {
             it('with undefined architecture', () => {
-                let error_thrown = false;
+                let errorThrown = false;
 
                 try {
                     new Net({
-                        input_architecture: [3],
-                        learning_rate: 0.02,
-                        layer_configs: [
+                        inputArchitecture: [3],
+                        learningRate: 0.02,
+                        layerConfigs: [
                             {
                                 type: 'FULLY_CONNECTED',
                                 options: {
@@ -162,11 +162,11 @@ describe('Fully Connected Layers', () => {
                     });
                 }
                 catch (err) {
-                    error_thrown = true;
+                    errorThrown = true;
                     expect(err.message).to.equal('Architecture must be array with at least one dimension');
                 }
 
-                expect(error_thrown).to.equal(true);
+                expect(errorThrown).to.equal(true);
             });
         });
     });
@@ -175,9 +175,9 @@ describe('Fully Connected Layers', () => {
         describe('can be created', () => {
             it('with one-dimensional architecture', () => {
                 const net = new Net({
-                    input_architecture: [3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'FULLY_CONNECTED',
                             options: {
@@ -200,9 +200,9 @@ describe('Fully Connected Layers', () => {
 
             it('with two-dimensional architecture', () => {
                 const net = new Net({
-                    input_architecture: [3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'FULLY_CONNECTED',
                             options: {
@@ -225,9 +225,9 @@ describe('Fully Connected Layers', () => {
 
             it('with three-dimensional architecture', () => {
                 const net = new Net({
-                    input_architecture: [3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'FULLY_CONNECTED',
                             options: {
@@ -250,9 +250,9 @@ describe('Fully Connected Layers', () => {
 
             it('with four-dimensional architecture', () => {
                 const net = new Net({
-                    input_architecture: [3],
-                    learning_rate: 0.02,
-                    layer_configs: [
+                    inputArchitecture: [3],
+                    learningRate: 0.02,
+                    layerConfigs: [
                         {
                             type: 'FULLY_CONNECTED',
                             options: {
@@ -276,13 +276,13 @@ describe('Fully Connected Layers', () => {
 
         describe('cannot be created', () => {
             it('with undefined architecture', () => {
-                let error_thrown = false;
+                let errorThrown = false;
 
                 try {
                     new Net({
-                        input_architecture: [3],
-                        learning_rate: 0.02,
-                        layer_configs: [
+                        inputArchitecture: [3],
+                        learningRate: 0.02,
+                        layerConfigs: [
                             {
                                 type: 'FULLY_CONNECTED',
                                 options: {
@@ -301,11 +301,11 @@ describe('Fully Connected Layers', () => {
                     });
                 }
                 catch (err) {
-                    error_thrown = true;
+                    errorThrown = true;
                     expect(err.message).to.equal('Architecture must be array with at least one dimension');
                 }
 
-                expect(error_thrown).to.equal(true);
+                expect(errorThrown).to.equal(true);
             });
         });
     });
@@ -313,9 +313,9 @@ describe('Fully Connected Layers', () => {
     describe('backpropagation:', () => {
         it('all activations are numbers', () => {
             const net = new Net({
-                input_architecture: [2],
-                learning_rate: 0.02,
-                layer_configs: [
+                inputArchitecture: [2],
+                learningRate: 0.02,
+                layerConfigs: [
                     {
                         type: 'FULLY_CONNECTED',
                         options: {
@@ -338,21 +338,21 @@ describe('Fully Connected Layers', () => {
             }
 
 
-            let all_numbers = true;
+            let allNumbers = true;
             net.layers[0].states.forEach((state) => {
                 const activation = net.layers[0].neuronsByState[state].activation;
                 if (typeof activation !== 'number') {
-                    all_numbers = false;
+                    allNumbers = false;
                 }
             });
-            expect(all_numbers).to.be.true;
+            expect(allNumbers).to.be.true;
         });
 
         it('all activations are not zero', () => {
             const net = new Net({
-                input_architecture: [2],
-                learning_rate: 0.02,
-                layer_configs: [
+                inputArchitecture: [2],
+                learningRate: 0.02,
+                layerConfigs: [
                     {
                         type: 'FULLY_CONNECTED',
                         options: {
@@ -374,14 +374,14 @@ describe('Fully Connected Layers', () => {
                 net.learn([Math.random(), Math.random()], [0, 1]);
             }
 
-            let all_zeroes = true;
+            let allZeroes = true;
             net.layers[0].states.forEach((state) => {
                 const activation = net.layers[0].neuronsByState[state].activation;
                 if (activation !== 0) {
-                    all_zeroes = false;
+                    allZeroes = false;
                 }
             });
-            expect(all_zeroes).to.be.false;
+            expect(allZeroes).to.be.false;
         });
     });
 });

--- a/specs/fullyConnectedLayer.spec.js
+++ b/specs/fullyConnectedLayer.spec.js
@@ -14,7 +14,7 @@ describe('Fully Connected Layers', () => {
                     layer_configs: [],
                 });
 
-                expect(Object.keys(net.layers[0].neurons)).to.have.length(3);
+                expect(net.layers[0].states).to.have.length(3);
             });
 
             it('with two-dimensional architecture', () => {
@@ -24,7 +24,7 @@ describe('Fully Connected Layers', () => {
                     layer_configs: [],
                 });
 
-                expect(Object.keys(net.layers[0].neurons)).to.have.length(12);
+                expect(net.layers[0].states).to.have.length(12);
             });
 
             it('with three-dimensional architecture', () => {
@@ -33,7 +33,7 @@ describe('Fully Connected Layers', () => {
                     input_architecture: [3, 4, 5],
                     layer_configs: [],
                 });
-                expect(Object.keys(net.layers[0].neurons)).to.have.length(60);
+                expect(net.layers[0].states).to.have.length(60);
             });
 
             it('with four-dimensional architecture', () => {
@@ -42,7 +42,7 @@ describe('Fully Connected Layers', () => {
                     input_architecture: [3, 4, 5, 6],
                     layer_configs: [],
                 });
-                expect(Object.keys(net.layers[0].neurons)).to.have.length(360);
+                expect(net.layers[0].states).to.have.length(360);
             });
         });
 
@@ -84,7 +84,7 @@ describe('Fully Connected Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(3);
+                expect(net.finalLayer.states).to.have.length(3);
             });
 
             it('with two-dimensional architecture', () => {
@@ -102,7 +102,7 @@ describe('Fully Connected Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(12);
+                expect(net.finalLayer.states).to.have.length(12);
             });
 
             it('with three-dimensional architecture', () => {
@@ -120,7 +120,7 @@ describe('Fully Connected Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(60);
+                expect(net.finalLayer.states).to.have.length(60);
             });
 
             it('with four-dimensional architecture', () => {
@@ -138,7 +138,7 @@ describe('Fully Connected Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(360);
+                expect(net.finalLayer.states).to.have.length(360);
             });
         });
 
@@ -195,7 +195,7 @@ describe('Fully Connected Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(3);
+                expect(net.finalLayer.states).to.have.length(3);
             });
 
             it('with two-dimensional architecture', () => {
@@ -220,7 +220,7 @@ describe('Fully Connected Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(12);
+                expect(net.finalLayer.states).to.have.length(12);
             });
 
             it('with three-dimensional architecture', () => {
@@ -245,7 +245,7 @@ describe('Fully Connected Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(60);
+                expect(net.finalLayer.states).to.have.length(60);
             });
 
             it('with four-dimensional architecture', () => {
@@ -270,7 +270,7 @@ describe('Fully Connected Layers', () => {
                     ]
                 });
 
-                expect(Object.keys(net.finalLayer.neurons)).to.have.length(360);
+                expect(net.finalLayer.states).to.have.length(360);
             });
         });
 
@@ -337,18 +337,14 @@ describe('Fully Connected Layers', () => {
                 net.learn([Math.random(), Math.random()], [0, 1]);
             }
 
-            const conv_neurons = net.layers[0].neurons;
-            const neuron_keys = Object.keys(conv_neurons);
-            let all_numbers = true;
 
-            for (var i = 0; i < neuron_keys.length; i++) {
-                const activation = conv_neurons[neuron_keys[i]].activation;
+            let all_numbers = true;
+            net.layers[0].states.forEach((state) => {
+                const activation = net.layers[0].neuronsByState[state].activation;
                 if (typeof activation !== 'number') {
                     all_numbers = false;
-                    break;
                 }
-            }
-
+            });
             expect(all_numbers).to.be.true;
         });
 
@@ -378,19 +374,13 @@ describe('Fully Connected Layers', () => {
                 net.learn([Math.random(), Math.random()], [0, 1]);
             }
 
-            const conv_neurons = net.layers[0].neurons;
-            const neuron_keys = Object.keys(conv_neurons);
             let all_zeroes = true;
-
-            for (var i = 0; i < neuron_keys.length; i++) {
-                const activation = conv_neurons[neuron_keys[i]].activation;
-
+            net.layers[0].states.forEach((state) => {
+                const activation = net.layers[0].neuronsByState[state].activation;
                 if (activation !== 0) {
                     all_zeroes = false;
-                    break;
                 }
-            }
-
+            });
             expect(all_zeroes).to.be.false;
         });
     });

--- a/specs/poolingLayer.spec.js
+++ b/specs/poolingLayer.spec.js
@@ -9,13 +9,13 @@ describe('Pooling Layers', () => {
     describe('can be created', () => {
         it('when spatial extent is compatible with input architecture', () => {
             const net = new Net({
-                input_architecture: [7, 7, 7],
-                learning_rate: 0.0000002,
-                layer_configs: [
+                inputArchitecture: [7, 7, 7],
+                learningRate: 0.0000002,
+                layerConfigs: [
                     {
                         type: 'CONVOLUTIONAL',
                         options: {
-                            filter_architecture: [4, 4, 4],
+                            filterArchitecture: [4, 4, 4],
                             depth: 1,
                             stride: 1,
                             rectifier: rectifiers.relu,
@@ -24,7 +24,7 @@ describe('Pooling Layers', () => {
                     {
                         type: 'POOLING',
                         options: {
-                            spatial_extent: 2
+                            spatialExtent: 2
                         }
                     }
                 ]
@@ -37,13 +37,13 @@ describe('Pooling Layers', () => {
     describe('backpropagation:', () => {
         it('all activations are numbers', () => {
             const net = new Net({
-                input_architecture: [9, 9, 3],
-                learning_rate: 0.000000002,
-                layer_configs: [
+                inputArchitecture: [9, 9, 3],
+                learningRate: 0.000000002,
+                layerConfigs: [
                     {
                         type: 'CONVOLUTIONAL',
                         options: {
-                            filter_architecture: [4, 4, 3],
+                            filterArchitecture: [4, 4, 3],
                             depth: 2,
                             stride: 1,
                             rectifier: rectifiers.relu,
@@ -52,7 +52,7 @@ describe('Pooling Layers', () => {
                     {
                         type: 'POOLING',
                         options: {
-                            spatial_extent: 2
+                            spatialExtent: 2
                         }
                     },
                     {
@@ -69,25 +69,25 @@ describe('Pooling Layers', () => {
                 .then((image) => {
                     net.learn(image, [0, 1]);
 
-                    let all_numbers = true;
+                    let allNumbers = true;
                     Object.values(net.layers[1].neuronsByState).forEach((neuron) => {
                         if (typeof neuron.activation !== 'number') {
-                            all_numbers = false;
+                            allNumbers = false;
                         }
                     });
-                    expect(all_numbers).to.be.true;
+                    expect(allNumbers).to.be.true;
                 });
         });
 
         it('all activations are not zero', () => {
             const net = new Net({
-                input_architecture: [9, 9, 3],
-                learning_rate: 0.000000002,
-                layer_configs: [
+                inputArchitecture: [9, 9, 3],
+                learningRate: 0.000000002,
+                layerConfigs: [
                     {
                         type: 'CONVOLUTIONAL',
                         options: {
-                            filter_architecture: [4, 4, 3],
+                            filterArchitecture: [4, 4, 3],
                             depth: 2,
                             stride: 1,
                             rectifier: rectifiers.relu,
@@ -96,7 +96,7 @@ describe('Pooling Layers', () => {
                     {
                         type: 'POOLING',
                         options: {
-                            spatial_extent: 2
+                            spatialExtent: 2
                         }
                     },
                     {
@@ -115,25 +115,25 @@ describe('Pooling Layers', () => {
                         net.learn(image, [Math.random(), Math.random()]);
                     }
 
-                    let all_zeroes = true;
+                    let allZeroes = true;
                     Object.values(net.layers[1].neuronsByState).forEach((neuron) => {
                         if (neuron.activation !== 0) {
-                            all_zeroes = false;
+                            allZeroes = false;
                         }
                     });
-                    expect(all_zeroes).to.be.false;
+                    expect(allZeroes).to.be.false;
                 });
         });
 
         it('predictions are numbers', () => {
             const net = new Net({
-                input_architecture: [9, 9, 3],
-                learning_rate: 0.000000002,
-                layer_configs: [
+                inputArchitecture: [9, 9, 3],
+                learningRate: 0.000000002,
+                layerConfigs: [
                     {
                         type: 'CONVOLUTIONAL',
                         options: {
-                            filter_architecture: [4, 4, 3],
+                            filterArchitecture: [4, 4, 3],
                             depth: 2,
                             stride: 1,
                             rectifier: rectifiers.relu,
@@ -142,7 +142,7 @@ describe('Pooling Layers', () => {
                     {
                         type: 'POOLING',
                         options: {
-                            spatial_extent: 2
+                            spatialExtent: 2
                         }
                     },
                     {
@@ -162,23 +162,23 @@ describe('Pooling Layers', () => {
                     }
 
                     const prediction = net.predict(image, [Math.random(), Math.random()]);
-                    const are_numbers = typeof prediction[0] === 'number' && typeof prediction[1] === 'number';
-                    const are_not_NaN = (Boolean(prediction[0]) || prediction[0] === 0) &&
+                    const areNumbers = typeof prediction[0] === 'number' && typeof prediction[1] === 'number';
+                    const areNotNaN = (Boolean(prediction[0]) || prediction[0] === 0) &&
                         (Boolean(prediction[1]) || prediction[1] === 0);
-                    expect(are_numbers).to.be.true;
-                    expect(are_not_NaN).to.be.true;
+                    expect(areNumbers).to.be.true;
+                    expect(areNotNaN).to.be.true;
                 });
         });
 
         it('[This scenario fails! Figure out why!]', () => {
             new Net({
-                input_architecture: [9, 9, 3],
-                learning_rate: 0.000000002,
-                layer_configs: [
+                inputArchitecture: [9, 9, 3],
+                learningRate: 0.000000002,
+                layerConfigs: [
                     {
                         type: 'CONVOLUTIONAL',
                         options: {
-                            filter_architecture: [4, 4, 3],
+                            filterArchitecture: [4, 4, 3],
                             depth: 2,
                             stride: 1,
                             rectifier: rectifiers.relu,
@@ -187,7 +187,7 @@ describe('Pooling Layers', () => {
                     {
                         type: 'CONVOLUTIONAL',
                         options: {
-                            filter_architecture: [4, 4, 1],
+                            filterArchitecture: [4, 4, 1],
                             depth: 1,
                             stride: 1,
                             rectifier: rectifiers.relu,
@@ -196,7 +196,7 @@ describe('Pooling Layers', () => {
                     {
                         type: 'POOLING',
                         options: {
-                            spatial_extent: 3
+                            spatialExtent: 3
                         }
                     },
                     {

--- a/specs/poolingLayer.spec.js
+++ b/specs/poolingLayer.spec.js
@@ -30,7 +30,7 @@ describe('Pooling Layers', () => {
                 ]
             });
 
-            expect(Object.keys(net.finalLayer.neurons)).to.have.length(16);
+            expect(net.finalLayer.states).to.have.length(16);
         });
     });
 
@@ -69,18 +69,12 @@ describe('Pooling Layers', () => {
                 .then((image) => {
                     net.learn(image, [0, 1]);
 
-                    const pooling_neurons = net.layers[1].neurons;
-                    const neuron_keys = Object.keys(pooling_neurons);
                     let all_numbers = true;
-
-                    for (var i = 0; i < neuron_keys.length; i++) {
-                        const activation = pooling_neurons[neuron_keys[i]].activation;
-                        if (typeof activation !== 'number') {
+                    Object.values(net.layers[1].neuronsByState).forEach((neuron) => {
+                        if (typeof neuron.activation !== 'number') {
                             all_numbers = false;
-                            break;
                         }
-                    }
-
+                    });
                     expect(all_numbers).to.be.true;
                 });
         });
@@ -121,19 +115,12 @@ describe('Pooling Layers', () => {
                         net.learn(image, [Math.random(), Math.random()]);
                     }
 
-                    const pooling_neurons = net.layers[1].neurons;
-                    const neuron_keys = Object.keys(pooling_neurons);
                     let all_zeroes = true;
-
-                    for (var i = 0; i < neuron_keys.length; i++) {
-                        const activation = pooling_neurons[neuron_keys[i]].activation;
-
-                        if (activation !== 0) {
+                    Object.values(net.layers[1].neuronsByState).forEach((neuron) => {
+                        if (neuron.activation !== 0) {
                             all_zeroes = false;
-                            break;
                         }
-                    }
-
+                    });
                     expect(all_zeroes).to.be.false;
                 });
         });


### PR DESCRIPTION
CHANGES
- use prefetched states array to avoid unnecessary iteration
- enforce camel case
- rename properties for readability (neurons --> neuronsByState)
- prefer class properties over arguments